### PR TITLE
fixed photo link

### DIFF
--- a/_plauscherl/42.html
+++ b/_plauscherl/42.html
@@ -30,5 +30,5 @@ speakers:
 -
   name: André Steingreß
   talk: Software Maintenance
-  img: //avatars3.githubusercontent.com/u/231265?v=3&s=400
+  img: //www.xing.com/image/e_5_4_32f0da962_11360780_9/andr%C3%A9-steingre%C3%9F-foto.1024x1024.jpg
 ---


### PR DESCRIPTION
mal das photo ebenfalls auf den Xing cache geändert. fancy titel folgt (hoffentlich) bald.