### PR TITLE
Add Magento Meetup Domain

### DIFF
--- a/_data/community.yml
+++ b/_data/community.yml
@@ -38,8 +38,9 @@
   events:
     -
       name: "Magento Meetup"
-      location: "Brucknerstudios"
+      location: "BrucknerStudios"
       date: 2017-03-21
+	  link: http://magewien.at/
 -
   id: socrates
   name: "SoCraTes Linz"


### PR DESCRIPTION
Still running on the old domain, will be redirected once we have the new domain for all meetups.