### PR TITLE
Remove proposal via email

### DIFF
--- a/pages/community-news.html
+++ b/pages/community-news.html
@@ -52,9 +52,9 @@ permalink: /community-news/
 
 <p>
   Hast du interssante Events für die Linzer Tech Community? Dann immer her damit.
-  Eine Nachricht auf organizers@technologieplauscherl.at oder ein Pull Request auf
+  Ein Pull Request auf
  <a href="https://github.com/technologieplauscherl/technologieplauscherl.github.io">GitHub</a>
- reichen um diese Veranstaltungen bei uns und den nächsten Plauscherln bekanntzugeben.
+ reicht um diese Veranstaltungen bei uns und in den nächsten Plauscherln bekanntzugeben.
 </p>
 <p>
   Bitte bedenke, dass die Events zum Thema des Technologieplauscherl passen sollen und


### PR DESCRIPTION
Community news should be added by a PR only, therefore remove the email part