### PR TITLE
Safari CSS fix: floating of cards / events

### DIFF
--- a/_sass/modules/_cards.scss
+++ b/_sass/modules/_cards.scss
@@ -19,7 +19,6 @@
   height: 13rem;
   margin: 1rem;
   flex: 1 0 auto;
-  width: 100%;
   color: white;
   position: relative;
   border: 1px solid #f6f6f6;

--- a/_sass/modules/_communitynews.scss
+++ b/_sass/modules/_communitynews.scss
@@ -9,15 +9,20 @@
 .event {
   font-size: 1.2rem;
   margin: 1rem;
-  width: 100%;
+  width: 350px;
   flex: 1 0 auto;
   position: relative;
   border: 1px solid #f6f6f6;
   background-color: #fff;
   color: $text-color;
   font-weight: normal;
-  max-width: 350px;
   display: flex;
+}
+
+@media(max-width: 400px) {
+  .event {
+    width: 100%;
+  }
 }
 
 .event__details {


### PR DESCRIPTION
On Safari (10, Mac) the cards and events are not floating as in other browsers, because of the width: 100%. This should fix it