### PR TITLE
Adds Softwerkskammer Wien & Global Day of Coderetreat

### DIFF
--- a/_data/community.yml
+++ b/_data/community.yml
@@ -167,6 +167,20 @@
       link: http://devone.at
       cost: EUR
 -
+  id: swkw
+  name: "Softwerkskammer Wien"
+  events:
+    -
+      name: "Global Day of Coderetreat (Day1)"
+      location: "Zühlke Engineering, Handelskai 92, Vienna"
+      date: 2019-11-15
+      link: https://www.softwerkskammer.org/activities/gdcr19-vienna-1
+    -
+      name: "Global Day of Coderetreat (Day2)"
+      location: "DC Spaces, Leonard-Bernstein-Straße 10, Vienna"
+      date: 2019-11-16
+      link: https://www.softwerkskammer.org/activities/gdcr19-vienna-2
+-
   id: reactday
   name: "React Day Berlin"
   events:


### PR DESCRIPTION
Free events for the Global Day of Coderetreat, different Location and different Hosts and participation is independent (one or other or both) -> created 2 entries, if this is too much, I can edit it down to one, but information might get mushy