### PR TITLE
Improve RSS feed: Switch to startDateIso8601 and include relevant information

### DIFF
--- a/feed.xml
+++ b/feed.xml
@@ -11,9 +11,13 @@ layout: none
     {% assign plauscherlReversed = site.plauscherl | sort: 'date' | reverse %}
     {% for post in plauscherlReversed limit:10 %}
       <item>
-        <title>{{ post.title | xml_escape }}</title>
-        <description>{{ post.content | xml_escape }}</description>
-        <pubDate>{{ post.datestring | date: "%a, %d %b %Y %H:%M:%S %z" }}</pubDate>
+        <title>{{ post.title | xml_escape }} | {{ post.startDateIso8601 | date: "%Y-%m-%d %H:%M" }} @ {{post.location.name | xml_escape }}</title>
+        <description>
+          {% for speaker in post.speakers %}
+            {{ speaker.name | xml_escape }}: {{ speaker.talk | xml_escape }}
+            <![CDATA[<br />]]>
+          {% endfor %}
+        </description>
         <link>{{ post.url | prepend: site.baseurl | prepend: site.url }}</link>
         <guid isPermaLink="true">{{ post.url | prepend: site.baseurl | prepend: site.url }}</guid>
       </item>


### PR DESCRIPTION
Removes 'pubDate' tag, as this is commonly used for specifying the date when the feed entry got updated. I could not find a jekyll-way of publishing that information, but I don't think that information is necessary.

Switched from using 'datestring' to 'startDateIso8601' as Jekyll could e.g. not parse 'datestring' from TP77. Furthermore, this PR includes the location in the title of the feed.

Changed the description from (non-existing) 'content' to list of speakers + talk title.