### PR TITLE
Add VALUG february meetup, update copyright year

### DIFF
--- a/_data/community.yml
+++ b/_data/community.yml
@@ -595,3 +595,10 @@
             location: "Tractive, Pasching"
             date: 2024-10-15
             link: https://www.linkedin.com/events/embeddedconnect2-07237411150873694208/
+-   id: valug
+    name: "Voralpen Linux User Group"
+    events:
+        -   name: "VALUG-Treffen - KI-Tools"
+            location: "VALUG-Klubraum, Alter Schl8hof Wels"
+            date: 2025-02-14
+            link: https://valug.at/events/2025-02-14/

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,7 +1,7 @@
 
   <footer>
     <p class="wrapper">
-      2022- Technologieplauscherl Linz  - <a href="/">Home</a> - <a href="/privacy">Datenschutz</a> - <a href="/feed">RSS</a> - <a href="http://twitter.com/plauscherl">Twitter</a>  - <a href="https://github.com/technologieplauscherl">GitHub</a> - <a href="https://www.youtube.com/c/Technologieplauscherl">YouTube</a> - <a href="/events.ics">.iCal</a>
+      {{ 'now' | date: "%Y" }} - Technologieplauscherl Linz  - <a href="/">Home</a> - <a href="/privacy">Datenschutz</a> - <a href="/feed">RSS</a> - <a href="http://twitter.com/plauscherl">Twitter</a>  - <a href="https://github.com/technologieplauscherl">GitHub</a> - <a href="https://www.youtube.com/c/Technologieplauscherl">YouTube</a> - <a href="/events.ics">.iCal</a>
     </p>
   </footer>
   <script>


### PR DESCRIPTION
I added the next VALUG meetup date. It is in Wels, but many people from Linz come there by train, so I think it is of interest to the Techplauscherl-Community.

I also noticed that the year still showed 2022 in the footer, so I made it dynamic.