### PR TITLE
Fix stats map info boxes

### DIFF
--- a/pages/stats.html
+++ b/pages/stats.html
@@ -180,7 +180,7 @@ permalink: /stats/
 
 			if (feature) {
 				popup.setPosition(feature.getGeometry().getCoordinates());
-				popup.getElement().innerHTML = '<div style="background: white; padding: 10px; border: 1px solid #ccc; border-radius: 4px; box-shadow: 0 2px 4px rgba(0,0,0,0.2);">' +
+				popup.getElement().innerHTML = '<div style="background: white; color: black; padding: 10px; border: 1px solid #ccc; border-radius: 4px; box-shadow: 0 2px 4px rgba(0,0,0,0.2);">' +
 					feature.get('name') + ': ' + feature.get('count') + 'x</div>';
 			} else {
 				popup.setPosition(undefined);


### PR DESCRIPTION
Darkmode toggles the font to white, which is counter productive as the boxes used in the map on the stats page are also white.

Before fix:
<img width="444" height="336" src="https://github.com/user-attachments/assets/8d5e0096-3a64-4882-aede-bb5f81d791e5" />

After fix:
<img width="438" height="280" src="https://github.com/user-attachments/assets/5388540c-c23d-4015-83b5-98e474f5aa3c" />


Surely there can be discussions if the box itself should be dark, but with the map being in light mode, I think it would look out of place.
