### PR TITLE
Enhance OpenGraph metadata handling

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,14 +1,38 @@
 <head>
-	<meta charset="UTF-8">
-	<title>{{site.title}}</title>
+	{% assign meta_title = page.title | default: site.title -%}
+	{% assign meta_description = page.description | default: site.description -%}
+	{% comment -%}
+		In addition to the default image, specify a page-specific image if on a plauscherl-page (e.g. technologieplauscherl.at/91)
+	{% endcomment -%}
+	{% assign additional_image = '' -%}
+	{% if page.layout == "post" -%}
+		{% assign event_image_name = page.name | split: '.' | first -%}
+		{% assign event_image = '/img/plauscherle/' | append: event_image_name | append: '.jpg' -%}
+		{% assign event_image_file = site.static_files | where: 'path', event_image -%}
+		{% if event_image_file and event_image_file.size > 0 -%}
+			{% assign additional_image = event_image | absolute_url -%}
+		{% endif -%}
+	{% endif -%}
 
-	<meta name="description" content="{{site.description}}">
+	<meta charset="UTF-8">
+	<title>{{ meta_title | escape }}</title>
+
+	<meta name="description" content="{{ meta_description | escape }}">
 	<meta name="keywords" content="{{site.keywords}}">
 	<meta name="theme-color" content="#49c096">
 	<meta name="google-site-verification" content="pYVLeFwZuLqAwZGkiLch6r_mhe15tH3DCv1NSEEOqCE" />
 	<meta name="google-site-verification" content="uF0j4H_YphrtLmukjDEHQmNNHoIJVkXOPLv38d0XjMU" />
-	<meta property="og:image" content="/img/tp-button.jpg">
-	<meta property="og:image" content="/img/orgas.jpg">
+	<meta property="og:type" content="website">
+	<meta property="og:locale" content="de_AT">
+	<meta property="og:title" content="{{ meta_title | escape }}">
+	<meta property="og:description" content="{{ meta_description | escape }}">
+	<meta property="og:url" content="{{ page.url | default: '/' | absolute_url }}">
+	<meta property="og:image" content="{{ '/img/tp-button.jpg' | absolute_url }}">
+	<meta property="og:image:width" content="389">
+	<meta property="og:image:height" content="389">
+	{% if additional_image -%}
+		<meta property="og:image" content="{{ additional_image }}">
+	{% endif -%}
 	<link rel="stylesheet" href="/css/main.css?3">
 	<meta name="viewport" content="width=device-width,initial-scale=1">
 	<link rel="alternate" type="application/rss+xml" title="Technologieplauscherl.at » Updates" href="https://www.technologieplauscherl.at/feed.xml">

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,10 +1,10 @@
 <head>
 	{% assign meta_title = page.title | default: site.title -%}
-	{% assign meta_description = page.description | default: site.description -%}
+	{% assign meta_description = page.og_description | default: site.description -%}
+	{% assign additional_image = page.og_image | default: '' -%}
 	{% comment -%}
 		In addition to the default image, specify a page-specific image if on a plauscherl-page (e.g. technologieplauscherl.at/91)
 	{% endcomment -%}
-	{% assign additional_image = '' -%}
 	{% if page.layout == "post" -%}
 		{% assign event_image_name = page.name | split: '.' | first -%}
 		{% assign event_image = '/img/plauscherle/' | append: event_image_name | append: '.jpg' -%}
@@ -31,7 +31,7 @@
 	<meta property="og:image:width" content="389">
 	<meta property="og:image:height" content="389">
 	{% if additional_image -%}
-		<meta property="og:image" content="{{ additional_image }}">
+		<meta property="og:image" content="{{ additional_image | escape}}">
 	{% endif -%}
 	<link rel="stylesheet" href="/css/main.css?3">
 	<meta name="viewport" content="width=device-width,initial-scale=1">

--- a/pages/archiv.html
+++ b/pages/archiv.html
@@ -2,6 +2,7 @@
 layout: page
 title: Archiv
 permalink: /archiv/
+og_description: "Alle vergangenen Veranstaltungen des Technologieplauscherls auf einen Blick."
 ---
 
 <div class="cards">

--- a/pages/faq.html
+++ b/pages/faq.html
@@ -2,6 +2,7 @@
 layout: page
 title: Technologieplauscherl - FAQ
 permalink: /faq/
+og_description: "Häufig gestellte Fragen zum Technologieplauscherl - von Vorträgen über Gastgeber bis hin zu Community-News."
 ---
 <div class="grid">
 	<h2>FAQ</h2>

--- a/pages/history.html
+++ b/pages/history.html
@@ -2,6 +2,8 @@
 layout: page
 title: Technologieplauscherl - Geschichte
 permalink: /history/
+og_image: /img/orgas.jpg
+og_description: "Wie ist das Technologieplauscherl entstanden? Wer sind die Gründer?"
 ---
 <div class="grid">
 	<h2>Geschichte</h2>


### PR DESCRIPTION
* Use event image when linking to an event directly
* Set locale, title, description and more for improved previews
* Allow custom image and description via `og_image` and `og_description` on a per-page base

**Before all references looked like this:**
<img width="541" height="383" alt="grafik" src="https://github.com/user-attachments/assets/e6aed6a0-6524-4801-a5f6-1c555e545f0c" /> 
or maybe with the [tp-button.jpg](https://github.com/technologieplauscherl/technologieplauscherl.github.io/blob/master/img/tp-button.jpg) depending on how the page actually implements the [Open Graph Protocol](https://ogp.me/).
I also saw both of them being squashed next to each other on certain platforms.

**With the changes, the default is:**
<img width="541" height="371" alt="grafik" src="https://github.com/user-attachments/assets/668a33ec-a748-4553-942d-6bce789d70f2" />

With references to specific talk pages (e.g. technologieplauscherl/91) showing the event "cover":
<img width="541" height="371" alt="grafik" src="https://github.com/user-attachments/assets/ba970078-a8f5-48f9-a4f7-c223780c3653" />

For something like the history page it will show the following with custom image and description:
<img width="541" height="371" alt="grafik" src="https://github.com/user-attachments/assets/50e4579d-dc70-45e4-8ff0-a1bfc5b59d09" />
