### PR TITLE
Add multi-speaker support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,13 @@ Du darfst dich gerne selbst als Speaker für das nächste Plauscherl auf der Web
 Dazu einfach das aktuellste Plauscherl-File unter /_plauscherl/ nehmen, und Folgendes hinzufügen:
 
 ```
--
-  name: <Dein Name>
-  talk: <Dein Talk>
-  img: <Bild (ohne Protokoll, nur mit `//`) zu deinem Facebook/Google/Twitter Foto>
-  language: "en"
-  abstract: "<Kurze Zusammenfassung deines Talks>"
+- title: <Dein Thema>
+  language: <"de" oder "en">
+  speakers:
+    - name: <Dein Name>
+      img: <Link zu einem Bild von dir, ohne "https://">
+    - name: <weiterer Speaker>
+      img: <Link zu einem Bild von diesem Speaker, ohne "https://">
 ```
+bei einem Vortrag mit mehreren Speakern zu einem Thema, einfach einen weiteren Eintrag unter "speakers" hinzufügen.
+Das Bild ist optional und sollte idealerweise quadratisch sein. Dieses kann unter [img/speaker-avatars](./img/speaker-avatars) abgelegt und dann referenziert werden.

--- a/_includes/masthead.html
+++ b/_includes/masthead.html
@@ -16,12 +16,15 @@
 			Danke für die Vorträge an
 		</p>
 		<ul class="no-bullets">
-			{% for speaker in post.speakers %}
+			{% for talk in post.talks %}
+				{% assign speaker_list = talk.speakers | default: talk.speaker %}
+				{% for speaker in speaker_list %}
 			<li>{{speaker.name}}</li>
+				{% endfor %}
 			{% endfor %}
 		</ul>
 		{% else %}
-		{% include speakers.html %}
+		{% include speakers.html post=post %}
 		{% endif %}
 		<p class="info">
 			{% unless page.dateset %}

--- a/_includes/speaker.html
+++ b/_includes/speaker.html
@@ -1,4 +1,8 @@
 <div class="speaker">
+	{% assign talk_title = include.talk | default: include.talk_legacy | default: include.speaker.talk %}
+	{% assign talk_link = include.talklink | default: include.speaker.talklink %}
+	{% assign talk_abstract = include.abstract | default: include.speaker.abstract %}
+	{% assign talk_language = include.language | default: include.speaker.language %}
 	<img 
 		{% if include.speaker.img == empty -%}
 			src="/img/speaker_no_image.jpg"
@@ -12,27 +16,27 @@
 		aria-hidden="true" class="speaker__img">
 	<div class="speaker__info">
 		<span class="speaker__name" itemprop="performer">{{include.speaker.name}}</span>
-		{% if include.speaker.talk %}
+		{% if talk_title %}
 			<div class="speaker__session">
-				{% if include.speaker.talklink %}
-					<a href="{{include.speaker.talklink}}">{{include.speaker.talk}}</a>
+				{% if talk_link %}
+					<a href="{{talk_link}}">{{talk_title}}</a>
 				{% else %}
-					<span class="speaker__talk-title">{{include.speaker.talk}}</span>
+					<span class="speaker__talk-title">{{talk_title}}</span>
 				{% endif %}
-				{% if include.speaker.abstract && include.speaker.abstract != empty %}
+				{% if talk_abstract && talk_abstract != empty %}
 					<details class="speaker__abstract-details">
-						<summary class="speaker__abstract-summary" aria-label="Abstract for {{include.speaker.talk}}">
+						<summary class="speaker__abstract-summary" aria-label="Abstract for {{talk_title}}">
 							<svg class="speaker__abstract-icon" aria-hidden="true">
 								<use xlink:href="#icon-info-circle"></use>
 							</svg>
 						</summary>
 						<div class="speaker__abstract" role="tooltip">
-							{{include.speaker.abstract}}
+							{{talk_abstract}}
 						</div>
 					</details>
 				{% endif %}
 			</div>
-			{% if include.speaker.language == "en" %}
+			{% if talk_language == "en" %}
 				<img class="speaker__language" src="/img/english-language.svg" width="40" height="20" alt="Vortrag ist auf Englisch / Talk is in English" title="Vortrag ist auf Englisch / Talk is in English">
 			{% else %}
 				<img class="speaker__language" src="/img/german-language.svg" width="40" height="20" alt="Vortrag ist auf Deutsch / Talk is in German" title="Vortrag ist auf Deutsch / Talk is in German">

--- a/_includes/speakers.html
+++ b/_includes/speakers.html
@@ -1,5 +1,14 @@
+{% assign talks_source = include.post | default: post | default: page %}
+{% if talks_source.talks and talks_source.talks != empty %}
+<div class="speakers speakers--talks" aria-label="Vorträge">
+  {% for talk in talks_source.talks %}
+    {% include talk.html talk=talk %}
+  {% endfor %}
+{% else %}
 <div class="speakers" aria-label="Vorträge">
-{% for speaker in post.speakers %}
-  {% include speaker.html speaker=speaker %}
-{% endfor %}
+  {% assign speaker_list = talks_source.speakers | default: talks_source.speaker %}
+  {% for speaker in speaker_list %}
+    {% include speaker.html speaker=speaker %}
+  {% endfor %}
+{% endif %}
 </div>

--- a/_includes/talk.html
+++ b/_includes/talk.html
@@ -1,0 +1,54 @@
+
+{% assign speaker_count = 0 %}
+{% if include.talk.speakers and include.talk.speakers != empty %}
+	{% assign speaker_count = include.talk.speakers | size %}
+{% elsif include.talk.speaker and include.talk.speaker != empty %}
+	{% assign speaker_count = 1 %}
+{% endif %}
+
+<article class="talk{% if speaker_count > 2 %} talk--many-speakers{% endif %}" itemscope itemtype="https://schema.org/CreativeWork">
+	<ul class="talk__speakers" aria-label="Speakers">
+		{% if include.talk.speakers and include.talk.speakers != empty %}
+			{% for speaker in include.talk.speakers %}
+				<li class="talk__speaker" itemprop="contributor" itemscope itemtype="https://schema.org/Person">
+					<img
+						{% if speaker.img == empty -%}
+							src="/img/speaker_no_image.jpg"
+						{% else -%}
+							src="{{speaker.img}}"
+						{% endif -%}
+						alt="{{speaker.name}}"
+						class="talk__speaker-img"
+						onerror="if (!this.src.endsWith('_no_image.png')) this.src = '/img/speaker_no_image.jpg'">
+					<span class="talk__speaker-name" itemprop="name">{{speaker.name}}</span>
+				</li>
+			{% endfor %}
+		{% elsif include.talk.speaker and include.talk.speaker != empty %}
+			<li class="talk__speaker" itemprop="contributor" itemscope itemtype="https://schema.org/Person">
+				<img
+					{% if include.talk.speaker.img == empty -%}
+						src="/img/speaker_no_image.jpg"
+					{% else -%}
+						src="{{include.talk.speaker.img}}"
+					{% endif -%}
+					alt="{{include.talk.speaker.name}}"
+					class="talk__speaker-img"
+					onerror="if (!this.src.endsWith('_no_image.png')) this.src = '/img/speaker_no_image.jpg'">
+				<span class="talk__speaker-name" itemprop="name">{{include.talk.speaker.name}}</span>
+			</li>
+		{% endif %}
+	</ul>
+
+	<header class="talk__header">
+		<h3 class="talk__title" itemprop="name">{{ include.talk.talk | default: include.talk.title }}</h3>
+		{% if include.talk.language == "en" %}
+			<img class="talk__language" src="/img/english-language.svg" width="40" height="20" alt="Talk is in English" title="Talk is in English">
+		{% else %}
+			<img class="talk__language" src="/img/german-language.svg" width="40" height="20" alt="Talk is in German" title="Talk is in German">
+		{% endif %}
+	</header>
+
+	{% if include.talk.abstract and include.talk.abstract != empty %}
+		<p class="talk__abstract">{{ include.talk.abstract }}</p>
+	{% endif %}
+</article>

--- a/_includes/talk.html
+++ b/_includes/talk.html
@@ -40,7 +40,21 @@
 	</ul>
 
 	<header class="talk__header">
-		<h3 class="talk__title" itemprop="name">{{ include.talk.talk | default: include.talk.title }}</h3>
+		<div class="talk__title-row">
+			<h3 class="talk__title" itemprop="name">{{ include.talk.talk | default: include.talk.title }}</h3>
+			{% if include.talk.abstract and include.talk.abstract != empty %}
+				<details class="talk__abstract-details">
+					<summary class="talk__abstract-summary" aria-label="Abstract for {{ include.talk.talk | default: include.talk.title }}">
+						<svg class="talk__abstract-icon" aria-hidden="true">
+							<use xlink:href="#icon-info-circle"></use>
+						</svg>
+					</summary>
+					<div class="talk__abstract" role="tooltip">
+						{{ include.talk.abstract }}
+					</div>
+				</details>
+			{% endif %}
+		</div>
 		{% if include.talk.language == "en" %}
 			<img class="talk__language" src="/img/english-language.svg" width="40" height="20" alt="Talk is in English" title="Talk is in English">
 		{% else %}
@@ -48,7 +62,9 @@
 		{% endif %}
 	</header>
 
-	{% if include.talk.abstract and include.talk.abstract != empty %}
-		<p class="talk__abstract">{{ include.talk.abstract }}</p>
+	{% if include.talk.talklink and include.talk.talklink != empty %}
+		<p class="talk__link">
+			<a href="{{ include.talk.talklink }}">Slides/Link</a>
+		</p>
 	{% endif %}
 </article>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -18,11 +18,7 @@ layout: default
 		</p>
 		<h2>Sessions</h2>
 
-		<section class="speakers">
-			{% for speaker in page.speakers %}
-			{% include speaker.html speaker=speaker %}
-			{% endfor %}
-		</section>
+		{% include speakers.html post=page %}
 
 		{{content}}
 

--- a/_plauscherl/01.html
+++ b/_plauscherl/01.html
@@ -16,17 +16,17 @@ location:
     lat: 48.303619026937284
     lng: 14.299148350489265
 sponsor: <a href="https://www.cloudflight.io">Catalysts GmbH</a>
-speakers:
--
-  name: Alexander Rosemann
-  talk: Sentiment Analysis mit R
-  img: //lh5.googleusercontent.com/-5ug0cZ1XgnY/AAAAAAAAAAI/AAAAAAAAAAA/iE-x6zqARSs/s128-c-k/photo.jpg
--
-  name: Phil Reither
-  talk: Fonts
-  img: //avatars2.githubusercontent.com/u/2776512?v=3&s=200
--
-  name: Dominik Hurnaus
-  talk: Google Play / Amazon Store
-  img: //avatars0.githubusercontent.com/u/106848?v=3&s=200
+talks:
+- title: "Sentiment Analysis mit R"
+  speakers:
+    - name: "Alexander Rosemann"
+      img: "//lh5.googleusercontent.com/-5ug0cZ1XgnY/AAAAAAAAAAI/AAAAAAAAAAA/iE-x6zqARSs/s128-c-k/photo.jpg"
+- title: "Fonts"
+  speakers:
+    - name: "Phil Reither"
+      img: "//avatars2.githubusercontent.com/u/2776512?v=3&s=200"
+- title: "Google Play / Amazon Store"
+  speakers:
+    - name: "Dominik Hurnaus"
+      img: "//avatars0.githubusercontent.com/u/106848?v=3&s=200"
 ---

--- a/_plauscherl/02.html
+++ b/_plauscherl/02.html
@@ -16,21 +16,21 @@ location:
     lat: 48.303619026937284
     lng: 14.299148350489265
 sponsor: <a href="https://www.cloudflight.io">Catalysts GmbH</a>
-speakers:
--
-  name: Phil Reither
-  talk: Unity is teh shit
-  img: //avatars2.githubusercontent.com/u/2776512?v=3&s=200
--
-  name: Alexander Rosemann 
-  talk: Find Information (Woosh)
-  img: //lh5.googleusercontent.com/-5ug0cZ1XgnY/AAAAAAAAAAI/AAAAAAAAAAA/iE-x6zqARSs/s128-c-k/photo.jpg
--
-  name: Michael Aspetsberger
-  talk: CUDA
-  img: //www.catalysts.cc/wp-content/uploads/userphoto/29.thumbnail.jpg
--
-  name: Dominik Hurnaus
-  talk: Android Development
-  img: //avatars0.githubusercontent.com/u/106848?v=3&s=200
+talks:
+- title: "Unity is teh shit"
+  speakers:
+    - name: "Phil Reither"
+      img: "//avatars2.githubusercontent.com/u/2776512?v=3&s=200"
+- title: "Find Information (Woosh)"
+  speakers:
+    - name: "Alexander Rosemann"
+      img: "//lh5.googleusercontent.com/-5ug0cZ1XgnY/AAAAAAAAAAI/AAAAAAAAAAA/iE-x6zqARSs/s128-c-k/photo.jpg"
+- title: "CUDA"
+  speakers:
+    - name: "Michael Aspetsberger"
+      img: "//www.catalysts.cc/wp-content/uploads/userphoto/29.thumbnail.jpg"
+- title: "Android Development"
+  speakers:
+    - name: "Dominik Hurnaus"
+      img: "//avatars0.githubusercontent.com/u/106848?v=3&s=200"
 ---

--- a/_plauscherl/03.html
+++ b/_plauscherl/03.html
@@ -15,21 +15,21 @@ location:
   coordinates: 
     lat: 48.302023063185295
     lng: 14.29142223072227
-speakers:
--
-  name: Elisabeth Adler
-  talk: Survival Analysis
-  img: //avatars2.githubusercontent.com/u/4456121?v=3&s=460
--
-  name: Dominik Hurnaus
-  talk: Marshmallow Challenge
-  img: //avatars0.githubusercontent.com/u/106848?v=3&s=200
--
-  name: Phil Reither
-  talk: Kanban - One Step before Anarchy
-  img: //avatars2.githubusercontent.com/u/2776512?v=3&s=200
--
-  name: Hannes Sachsenhofer
-  talk: Git and why it's cooler than SVN
-  img: //avatars2.githubusercontent.com/u/1190606?v=3&s=200
+talks:
+- title: "Survival Analysis"
+  speakers:
+    - name: "Elisabeth Adler"
+      img: "//avatars2.githubusercontent.com/u/4456121?v=3&s=460"
+- title: "Marshmallow Challenge"
+  speakers:
+    - name: "Dominik Hurnaus"
+      img: "//avatars0.githubusercontent.com/u/106848?v=3&s=200"
+- title: "Kanban - One Step before Anarchy"
+  speakers:
+    - name: "Phil Reither"
+      img: "//avatars2.githubusercontent.com/u/2776512?v=3&s=200"
+- title: "Git and why it's cooler than SVN"
+  speakers:
+    - name: "Hannes Sachsenhofer"
+      img: "//avatars2.githubusercontent.com/u/1190606?v=3&s=200"
 ---

--- a/_plauscherl/04.html
+++ b/_plauscherl/04.html
@@ -16,25 +16,25 @@ location:
     lat: 48.303619026937284
     lng: 14.299148350489265
 sponsor: <a href="https://www.cloudflight.io">Catalysts GmbH</a>
-speakers:
--
-  name: Alexander Floh
-  talk: Scala
-  img: //avatars3.githubusercontent.com/u/3514359?v=3&s=200
--
-  name: Paul Weber
-  talk: Groovy
-  img: //avatars3.githubusercontent.com/u/499094?v=3&s=200
--
-  name: Klaus Lehner
-  talk: Gradle - Goodbye, Maven, ANT & Ivy
-  img: //avatars0.githubusercontent.com/u/172195?v=3&s=200
--
-  name: Thomas Einwaller
-  talk: Grails - yet another web application framework?
-  img: //avatars0.githubusercontent.com/u/103224?v=3&s=200
--
-  name: Helmut Juskewycz
-  talk: (J)Ruby on Rails, JRuby, Rails
-  img: //avatars1.githubusercontent.com/u/306573?v=3&s=200
+talks:
+- title: "Scala"
+  speakers:
+    - name: "Alexander Floh"
+      img: "//avatars3.githubusercontent.com/u/3514359?v=3&s=200"
+- title: "Groovy"
+  speakers:
+    - name: "Paul Weber"
+      img: "//avatars3.githubusercontent.com/u/499094?v=3&s=200"
+- title: "Gradle - Goodbye, Maven, ANT & Ivy"
+  speakers:
+    - name: "Klaus Lehner"
+      img: "//avatars0.githubusercontent.com/u/172195?v=3&s=200"
+- title: "Grails - yet another web application framework?"
+  speakers:
+    - name: "Thomas Einwaller"
+      img: "//avatars0.githubusercontent.com/u/103224?v=3&s=200"
+- title: "(J)Ruby on Rails, JRuby, Rails"
+  speakers:
+    - name: "Helmut Juskewycz"
+      img: "//avatars1.githubusercontent.com/u/306573?v=3&s=200"
 ---

--- a/_plauscherl/05.html
+++ b/_plauscherl/05.html
@@ -14,16 +14,16 @@ location:
   coordinates:
     lat: 48.243419
     lng: 14.236858
-speakers:
--
-  name: Christoph Hochstrasser
-  talk: Wieso PHP nicht Scheiße ist
--
-  name: Tom Profelt
-  talk: Web Components
-  img: //avatars3.githubusercontent.com/u/440368?v=3&s=200
--
-  name: Phil Reither
-  talk: How to take awesome photos without being awesome (dslr)
-  img: //avatars2.githubusercontent.com/u/2776512?v=3&s=200
+talks:
+- title: "Wieso PHP nicht Scheiße ist"
+  speakers:
+    - name: "Christoph Hochstrasser"
+- title: "Web Components"
+  speakers:
+    - name: "Tom Profelt"
+      img: "//avatars3.githubusercontent.com/u/440368?v=3&s=200"
+- title: "How to take awesome photos without being awesome (dslr)"
+  speakers:
+    - name: "Phil Reither"
+      img: "//avatars2.githubusercontent.com/u/2776512?v=3&s=200"
 ---

--- a/_plauscherl/06.html
+++ b/_plauscherl/06.html
@@ -15,19 +15,19 @@ location:
   coordinates:
     lat: 48.29661
     lng: 14.29581
-speakers:
--
-  name: Mario Aichlseder
-  talk: Akostart
--
-  name: Andrzej Kozlowski
-  talk: Gamification explained from a gamer's point of view
--
-  name: Phil Reither
-  talk: CSS for Programmers
-  img: //avatars2.githubusercontent.com/u/2776512?v=3&s=200
--
-  name: Elisabeth Adler
-  talk: SafePowder Analyse - Einschätzung von Lawinenrisiko
-  img: //avatars2.githubusercontent.com/u/4456121?v=3&s=460
+talks:
+- title: "Akostart"
+  speakers:
+    - name: "Mario Aichlseder"
+- title: "Gamification explained from a gamer's point of view"
+  speakers:
+    - name: "Andrzej Kozlowski"
+- title: "CSS for Programmers"
+  speakers:
+    - name: "Phil Reither"
+      img: "//avatars2.githubusercontent.com/u/2776512?v=3&s=200"
+- title: "SafePowder Analyse - Einschätzung von Lawinenrisiko"
+  speakers:
+    - name: "Elisabeth Adler"
+      img: "//avatars2.githubusercontent.com/u/4456121?v=3&s=460"
 ---

--- a/_plauscherl/07.html
+++ b/_plauscherl/07.html
@@ -15,21 +15,21 @@ location:
   coordinates: 
     lat: 48.29661
     lng: 14.29581
-speakers:
--
-  name: Hannes Sachsenhofer
-  talk: How to build something cool in an evening on Windows
-  img: //avatars2.githubusercontent.com/u/1190606?v=3&s=200
--
-  name: Alex Seifert
-  talk: Flash Games
-  img: //fbcdn-profile-a.akamaihd.net/hprofile-ak-xap1/t1.0-1/c2.100.716.716/s160x160/10171289_10201812924110871_647201085_n.jpg
--
-  name: Phil Reither
-  talk: Responsive Patterns
-  img: //avatars2.githubusercontent.com/u/2776512?v=3&s=200s
--
-  name: Dominik Hurnaus
-  talk: The Responsibility Process  - Teams, Motivation, Wissensaustausch
-  img: //avatars0.githubusercontent.com/u/106848?v=3&s=200
+talks:
+- title: "How to build something cool in an evening on Windows"
+  speakers:
+    - name: "Hannes Sachsenhofer"
+      img: "//avatars2.githubusercontent.com/u/1190606?v=3&s=200"
+- title: "Flash Games"
+  speakers:
+    - name: "Alex Seifert"
+      img: "//fbcdn-profile-a.akamaihd.net/hprofile-ak-xap1/t1.0-1/c2.100.716.716/s160x160/10171289_10201812924110871_647201085_n.jpg"
+- title: "Responsive Patterns"
+  speakers:
+    - name: "Phil Reither"
+      img: "//avatars2.githubusercontent.com/u/2776512?v=3&s=200s"
+- title: "The Responsibility Process  - Teams, Motivation, Wissensaustausch"
+  speakers:
+    - name: "Dominik Hurnaus"
+      img: "//avatars0.githubusercontent.com/u/106848?v=3&s=200"
 ---

--- a/_plauscherl/08.html
+++ b/_plauscherl/08.html
@@ -14,25 +14,25 @@ location:
   coordinates: 
     lat: 48.29710
     lng: 14.30344
-speakers:
--
-  name: Phil Reither
-  talk: "Buch: Brain Rules"
-  img: //avatars2.githubusercontent.com/u/2776512?v=3&s=200
--
-  name: Joachim Sauer
-  talk: "Buch: Liars and Outliers"
-  img: //lh5.googleusercontent.com/-lTDEEVEx_Og/AAAAAAAAAAI/AAAAAAAAjbw/rEagVv8yZOo/s120-c/photo.jpg
--
-  name: Thomas Einwaller
-  talk: "Buch: Release It!"
-  img: //avatars0.githubusercontent.com/u/103224?v=3&s=200
--
-  name: Stefan Baumgartner
-  talk: "Buch: SMACSS"
-  img: //avatars3.githubusercontent.com/u/1374451?v=3&s=200
--
-  name: Bernhard Wurm
-  talk: TypeScript
-  img: //fbcdn-profile-a.akamaihd.net/hprofile-ak-xfa1/t1.0-1/c16.16.203.203/s160x160/1005885_4439820572829_1200736474_n.jpg
+talks:
+- title: "Buch: Brain Rules"
+  speakers:
+    - name: "Phil Reither"
+      img: "//avatars2.githubusercontent.com/u/2776512?v=3&s=200"
+- title: "Buch: Liars and Outliers"
+  speakers:
+    - name: "Joachim Sauer"
+      img: "//lh5.googleusercontent.com/-lTDEEVEx_Og/AAAAAAAAAAI/AAAAAAAAjbw/rEagVv8yZOo/s120-c/photo.jpg"
+- title: "Buch: Release It!"
+  speakers:
+    - name: "Thomas Einwaller"
+      img: "//avatars0.githubusercontent.com/u/103224?v=3&s=200"
+- title: "Buch: SMACSS"
+  speakers:
+    - name: "Stefan Baumgartner"
+      img: "//avatars3.githubusercontent.com/u/1374451?v=3&s=200"
+- title: "TypeScript"
+  speakers:
+    - name: "Bernhard Wurm"
+      img: "//fbcdn-profile-a.akamaihd.net/hprofile-ak-xfa1/t1.0-1/c16.16.203.203/s160x160/1005885_4439820572829_1200736474_n.jpg"
 ---

--- a/_plauscherl/09.html
+++ b/_plauscherl/09.html
@@ -14,21 +14,21 @@ location:
   coordinates: 
     lat: 48.302023063185295
     lng: 14.29142223072227
-speakers:
--
-  name: Hannes Sachsenhofer
-  talk: PaaS via GitHub, AppHarbor und Azure
-  img: //avatars2.githubusercontent.com/u/1190606?v=3&s=200
--
-  name: Christina Feilmayr
-  talk: Textmining Part 1
-  img: //fbcdn-profile-a.akamaihd.net/hprofile-ak-xpa1/t1.0-1/p160x160/10325623_10201949509241781_2127667093409437054_n.jpg
--
-  name: Phil Reither
-  talk: Phil's Random Topic.
-  img: //avatars2.githubusercontent.com/u/2776512?v=3&s=200
--
-  name: Thomas Einwaller
-  talk: Serving images via Amazon CloudFront
-  img: //avatars0.githubusercontent.com/u/103224?v=3&s=200
+talks:
+- title: "PaaS via GitHub, AppHarbor und Azure"
+  speakers:
+    - name: "Hannes Sachsenhofer"
+      img: "//avatars2.githubusercontent.com/u/1190606?v=3&s=200"
+- title: "Textmining Part 1"
+  speakers:
+    - name: "Christina Feilmayr"
+      img: "//fbcdn-profile-a.akamaihd.net/hprofile-ak-xpa1/t1.0-1/p160x160/10325623_10201949509241781_2127667093409437054_n.jpg"
+- title: "Phil's Random Topic."
+  speakers:
+    - name: "Phil Reither"
+      img: "//avatars2.githubusercontent.com/u/2776512?v=3&s=200"
+- title: "Serving images via Amazon CloudFront"
+  speakers:
+    - name: "Thomas Einwaller"
+      img: "//avatars0.githubusercontent.com/u/103224?v=3&s=200"
 ---

--- a/_plauscherl/10.html
+++ b/_plauscherl/10.html
@@ -15,17 +15,17 @@ location:
     lat: 48.303619026937284
     lng: 14.299148350489265
 sponsor: <a href="https://www.cloudflight.io">Catalysts GmbH</a>
-speakers:
--
-  name: Paul Klingelhuber
-  talk: knockout.js data binding - or - why you are doing ajax wrong
-  img: //fbcdn-profile-a.akamaihd.net/hprofile-ak-ash2/484050_10151326811119746_578315574_a.jpg
--
-  name: Harald Vogl
-  talk: A simple way of cross platform mobile development.
-  img: //fbcdn-profile-a.akamaihd.net/hprofile-ak-prn1/t1/c51.134.640.640/s200x200/384885_332202696797337_781807793_n.jpg
--
-  name: Christoph Stichlberger
-  talk: Making Big Dollar in Stocks with Fourier Transforms
-  img: //fbcdn-profile-a.akamaihd.net/hprofile-ak-prn2/t1/c22.0.157.157/6248_1090874964647_7294244_n.jpg
+talks:
+- title: "knockout.js data binding - or - why you are doing ajax wrong"
+  speakers:
+    - name: "Paul Klingelhuber"
+      img: "//fbcdn-profile-a.akamaihd.net/hprofile-ak-ash2/484050_10151326811119746_578315574_a.jpg"
+- title: "A simple way of cross platform mobile development."
+  speakers:
+    - name: "Harald Vogl"
+      img: "//fbcdn-profile-a.akamaihd.net/hprofile-ak-prn1/t1/c51.134.640.640/s200x200/384885_332202696797337_781807793_n.jpg"
+- title: "Making Big Dollar in Stocks with Fourier Transforms"
+  speakers:
+    - name: "Christoph Stichlberger"
+      img: "//fbcdn-profile-a.akamaihd.net/hprofile-ak-prn2/t1/c22.0.157.157/6248_1090874964647_7294244_n.jpg"
 ---

--- a/_plauscherl/11.html
+++ b/_plauscherl/11.html
@@ -14,17 +14,17 @@ location:
   coordinates: 
     lat: 48.36847129469092
     lng: 14.513135120878614
-speakers:
--
-  name: Manuel Berger
-  talk: Startup Lessons Learned (technical perspective)
-  img: //avatars0.githubusercontent.com/u/1924009
--
-  name: Attila Jakabfi
-  talk: Introduction to Groovy / How to make popcorn in the micro wave oven.
-  img: //fbcdn-profile-a.akamaihd.net/hprofile-ak-ash3/t1/c34.34.419.419/s200x200/943271_10151514821892983_561540714_n.jpg
--
-  name: Florian Brunner, Erik Rusek
-  talk: "Web Application Security - Major Mistakes and Lessons Learned / How to use the cloud for secure software projects."
-  img: //fbcdn-profile-a.akamaihd.net/hprofile-ak-ash2/t1/c0.16.200.200/p200x200/1461657_330941753714601_72797686_n.png
+talks:
+- title: "Startup Lessons Learned (technical perspective)"
+  speakers:
+    - name: "Manuel Berger"
+      img: "//avatars0.githubusercontent.com/u/1924009"
+- title: "Introduction to Groovy / How to make popcorn in the micro wave oven."
+  speakers:
+    - name: "Attila Jakabfi"
+      img: "//fbcdn-profile-a.akamaihd.net/hprofile-ak-ash3/t1/c34.34.419.419/s200x200/943271_10151514821892983_561540714_n.jpg"
+- title: "Web Application Security - Major Mistakes and Lessons Learned / How to use the cloud for secure software projects."
+  speakers:
+    - name: "Florian Brunner"
+    - name: "Erik Rusek"
 ---

--- a/_plauscherl/12.html
+++ b/_plauscherl/12.html
@@ -14,17 +14,17 @@ location:
   coordinates: 
     lat: 48.29661
     lng: 14.29581
-speakers:
--
-  name: Joachim Sauer
-  talk: There's not just Spring?
-  img: //lh5.googleusercontent.com/-lTDEEVEx_Og/AAAAAAAAAAI/AAAAAAAAjbw/rEagVv8yZOo/s120-c/photo.jpg
--
-  name: Dominik Hurnaus
-  talk: Introduction to Google AppEngine
-  img: //avatars0.githubusercontent.com/u/106848?v=3&s=200
--
-  name: Hannes Sachsenhofer
-  talk: Getting started with SignalR
-  img: //avatars2.githubusercontent.com/u/1190606?v=3&s=200
+talks:
+- title: "There's not just Spring?"
+  speakers:
+    - name: "Joachim Sauer"
+      img: "//lh5.googleusercontent.com/-lTDEEVEx_Og/AAAAAAAAAAI/AAAAAAAAjbw/rEagVv8yZOo/s120-c/photo.jpg"
+- title: "Introduction to Google AppEngine"
+  speakers:
+    - name: "Dominik Hurnaus"
+      img: "//avatars0.githubusercontent.com/u/106848?v=3&s=200"
+- title: "Getting started with SignalR"
+  speakers:
+    - name: "Hannes Sachsenhofer"
+      img: "//avatars2.githubusercontent.com/u/1190606?v=3&s=200"
 ---

--- a/_plauscherl/13.html
+++ b/_plauscherl/13.html
@@ -15,21 +15,21 @@ location:
   coordinates: 
     lat: 48.29710
     lng: 14.30344
-speakers:
--
-  name: Dominik Hurnaus
-  talk: Google Analytics for Mobile Apps
-  img: //avatars0.githubusercontent.com/u/106848?v=3&s=200
--
-  name: Stefan Baumgartner
-  talk: Mobile Browser Games
-  img: //avatars3.githubusercontent.com/u/1374451?v=3&s=200
--
-  name: Erik Rusek und Jürgen Grieshofer
-  talk: OWASP Top Ten in 20 Minuten
-  img: //fbcdn-profile-a.akamaihd.net/hprofile-ak-ash2/t1/c0.20.254.254/s200x200/1461657_330941753714601_72797686_n.png
--
-  name: Elisabeth Adler
-  talk: Apache Solr (Facetten und andere Spielereien)
-  img: //avatars2.githubusercontent.com/u/4456121?v=3&s=460
+talks:
+- title: "Google Analytics for Mobile Apps"
+  speakers:
+    - name: "Dominik Hurnaus"
+      img: "//avatars0.githubusercontent.com/u/106848?v=3&s=200"
+- title: "Mobile Browser Games"
+  speakers:
+    - name: "Stefan Baumgartner"
+      img: "//avatars3.githubusercontent.com/u/1374451?v=3&s=200"
+- title: "OWASP Top Ten in 20 Minuten"
+  speakers:
+    - name: "Erik Rusek"
+    - name: "Jürgen Grieshofer"
+- title: "Apache Solr (Facetten und andere Spielereien)"
+  speakers:
+    - name: "Elisabeth Adler"
+      img: "//avatars2.githubusercontent.com/u/4456121?v=3&s=460"
 ---

--- a/_plauscherl/14.html
+++ b/_plauscherl/14.html
@@ -15,21 +15,21 @@ location:
   coordinates: 
     lat: 48.30598951404664
     lng: 14.28387213366297
-speakers:
--
-  name: Manuel Berger
-  talk: Telefonbot mit Twilio
-  img: //avatars0.githubusercontent.com/u/1924009
--
-  name: Thomas Einwaller
-  talk: vagrant und docker
-  img: //avatars0.githubusercontent.com/u/103224?v=3&s=200
--
-  name: Stefan Baumgartner
-  talk: "Frontend-Tooling: Emmet, Sass"
-  img: //avatars3.githubusercontent.com/u/1374451?v=3&s=200
--
-  name: Thomas Knoll
-  talk: DNA Game
-  img: //fbcdn-profile-a.akamaihd.net/hprofile-ak-frc3/c0.0.180.180/s160x160/1385624_174423526082097_28285060_a.jpg
+talks:
+- title: "Telefonbot mit Twilio"
+  speakers:
+    - name: "Manuel Berger"
+      img: "//avatars0.githubusercontent.com/u/1924009"
+- title: "vagrant und docker"
+  speakers:
+    - name: "Thomas Einwaller"
+      img: "//avatars0.githubusercontent.com/u/103224?v=3&s=200"
+- title: "Frontend-Tooling: Emmet, Sass"
+  speakers:
+    - name: "Stefan Baumgartner"
+      img: "//avatars3.githubusercontent.com/u/1374451?v=3&s=200"
+- title: "DNA Game"
+  speakers:
+    - name: "Thomas Knoll"
+      img: "//fbcdn-profile-a.akamaihd.net/hprofile-ak-frc3/c0.0.180.180/s160x160/1385624_174423526082097_28285060_a.jpg"
 ---

--- a/_plauscherl/15.html
+++ b/_plauscherl/15.html
@@ -16,20 +16,20 @@ location:
     lat: 48.329348
     lng: 14.3202109
 sponsor: <a href="https://www.dynatrace.com">Compuware GmbH (ehem. Dynatrace)</a>
-speakers:
--
-  name: Daniel Khan
-  talk: Scala Play als REST Backend zu mongodb für ein node.js Frontend
-  img: //fbcdn-profile-a.akamaihd.net/hprofile-ak-ash3/c88.26.324.324/s160x160/2706_1049293921262_5828179_n.jpg
--
-  name: Manuel Berger
-  talk: Geolocation for Web - GeoIP & W3C Location, Geohashing
-  img: //avatars0.githubusercontent.com/u/1924009
--
-  name: Wolfgang Gottesheim
-  talk: Continuous Performance Testing in CI
-  img: //fbcdn-profile-a.akamaihd.net/hprofile-ak-ash2/c111.45.567.567/s160x160/291981_2323472856303_1336799925_n.jpg
--
-  name: Karl-Michael Edlinger
-  talk: Why assertions suck and what we can do about it
+talks:
+- title: "Scala Play als REST Backend zu mongodb für ein node.js Frontend"
+  speakers:
+    - name: "Daniel Khan"
+      img: "//fbcdn-profile-a.akamaihd.net/hprofile-ak-ash3/c88.26.324.324/s160x160/2706_1049293921262_5828179_n.jpg"
+- title: "Geolocation for Web - GeoIP & W3C Location, Geohashing"
+  speakers:
+    - name: "Manuel Berger"
+      img: "//avatars0.githubusercontent.com/u/1924009"
+- title: "Continuous Performance Testing in CI"
+  speakers:
+    - name: "Wolfgang Gottesheim"
+      img: "//fbcdn-profile-a.akamaihd.net/hprofile-ak-ash2/c111.45.567.567/s160x160/291981_2323472856303_1336799925_n.jpg"
+- title: "Why assertions suck and what we can do about it"
+  speakers:
+    - name: "Karl-Michael Edlinger"
 ---

--- a/_plauscherl/16.html
+++ b/_plauscherl/16.html
@@ -16,20 +16,20 @@ location:
     lat: 48.303619026937284
     lng: 14.299148350489265
 sponsor: <a href="https://www.cloudflight.io">Catalysts GmbH</a>
-speakers:
--
-  name: André Steingreß
-  talk: Clojure
-  img: //fbcdn-profile-a.akamaihd.net/hprofile-ak-ash3/c49.49.619.619/s160x160/227052_135197649969146_1125277772_n.jpg
--
-  name: Markus Schmidinger
-  talk: Neo-Keyboard-Layout
--
-  name: Stefan Baumgartner
-  talk: GitHub Pages/Jekyll
-  img: //avatars3.githubusercontent.com/u/1374451?v=3&s=200
--
-  name: Florian Neumann
-  talk: "Buch über CSS: SMACSS"
-  img: //fbcdn-profile-a.akamaihd.net/hprofile-ak-prn1/t1/c50.50.621.621/s200x200/296636_4561837011895_66238352_n.jpg
+talks:
+- title: "Clojure"
+  speakers:
+    - name: "André Steingreß"
+      img: "//fbcdn-profile-a.akamaihd.net/hprofile-ak-ash3/c49.49.619.619/s160x160/227052_135197649969146_1125277772_n.jpg"
+- title: "Neo-Keyboard-Layout"
+  speakers:
+    - name: "Markus Schmidinger"
+- title: "GitHub Pages/Jekyll"
+  speakers:
+    - name: "Stefan Baumgartner"
+      img: "//avatars3.githubusercontent.com/u/1374451?v=3&s=200"
+- title: "Buch über CSS: SMACSS"
+  speakers:
+    - name: "Florian Neumann"
+      img: "//fbcdn-profile-a.akamaihd.net/hprofile-ak-prn1/t1/c50.50.621.621/s200x200/296636_4561837011895_66238352_n.jpg"
 ---

--- a/_plauscherl/17.html
+++ b/_plauscherl/17.html
@@ -16,16 +16,16 @@ location:
     lat: 48.303619026937284
     lng: 14.299148350489265
 sponsor: <a href="https://www.cloudflight.io">Catalysts GmbH</a>
-speakers:
--
-  name: Karl-Michael Edlinger
-  talk: Effective Code Reviews
--
-  name: Dominik Hurnaus
-  talk: AngularJS - Databinding / MVC / Dependency Injection
-  img: //avatars0.githubusercontent.com/u/106848?v=3&s=200
--
-  name: Michael Hurnaus
-  talk: Produktentwicklung bei Amazon
-  img: //fbcdn-profile-a.akamaihd.net/hprofile-ak-frc3/t1.0-1/p160x160/1463085_10151847745278246_473952397_n.jpg
+talks:
+- title: "Effective Code Reviews"
+  speakers:
+    - name: "Karl-Michael Edlinger"
+- title: "AngularJS - Databinding / MVC / Dependency Injection"
+  speakers:
+    - name: "Dominik Hurnaus"
+      img: "//avatars0.githubusercontent.com/u/106848?v=3&s=200"
+- title: "Produktentwicklung bei Amazon"
+  speakers:
+    - name: "Michael Hurnaus"
+      img: "//fbcdn-profile-a.akamaihd.net/hprofile-ak-frc3/t1.0-1/p160x160/1463085_10151847745278246_473952397_n.jpg"
 ---

--- a/_plauscherl/18.html
+++ b/_plauscherl/18.html
@@ -14,17 +14,17 @@ location:
   coordinates:
     lat: 48.315
     lng: 14.303
-speakers:
--
-  name: Thomas Scheinecker
-  talk: Gulp - the streaming build system
-  img: //fbcdn-profile-a.akamaihd.net/hprofile-ak-frc3/t1.0-1/c50.50.621.621/s160x160/189204_4722750265928_1373196634_n.jpg
--
-  name: Helmut Juskewycz
-  talk: How to translate your software to 40+ languages without losing your sanity.
-  img: //avatars1.githubusercontent.com/u/306573?v=3&s=200
--
-  name: Klaus Lehner
-  talk: Use Swagger to document your REST APIs in Spring Boot applications.
-  img: //avatars0.githubusercontent.com/u/172195?v=3&s=200
+talks:
+- title: "Gulp - the streaming build system"
+  speakers:
+    - name: "Thomas Scheinecker"
+      img: "//fbcdn-profile-a.akamaihd.net/hprofile-ak-frc3/t1.0-1/c50.50.621.621/s160x160/189204_4722750265928_1373196634_n.jpg"
+- title: "How to translate your software to 40+ languages without losing your sanity."
+  speakers:
+    - name: "Helmut Juskewycz"
+      img: "//avatars1.githubusercontent.com/u/306573?v=3&s=200"
+- title: "Use Swagger to document your REST APIs in Spring Boot applications."
+  speakers:
+    - name: "Klaus Lehner"
+      img: "//avatars0.githubusercontent.com/u/172195?v=3&s=200"
 ---

--- a/_plauscherl/19.html
+++ b/_plauscherl/19.html
@@ -18,21 +18,21 @@ location:
   coordinates:
     lat: 48.3125250952205
     lng: 14.298081718795546
-speakers:
--
-  name: Thomas Einwaller
-  talk: Why podcasts are awesome
-  img: //avatars0.githubusercontent.com/u/103224?v=3&s=200
--
-  name: Hannes Sachsenhofer
-  talk: Why Visual Studio is a great web IDE
-  img: //avatars2.githubusercontent.com/u/1190606?v=3&s=200
--
-  name: Stefan Schraml
-  talk: Retrogames
-  img: //fbcdn-profile-a.akamaihd.net/hprofile-ak-xaf1/t1.0-1/c66.33.407.407/s160x160/319952_2199421196546_1963878823_n.jpg
--
-  name: Stephan Schober
-  talk: Google Cloud Endpoints for Android
-  img: "//fbcdn-profile-a.akamaihd.net/hprofile-ak-xap1/v/t1.0-1/c0.0.160.160/p160x160/1476474_10201015987223192_1808483175_n.jpg?oh=eb77d585672cef5b3f73b68d23cc367b&oe=54539056&__gda__=1414733406_9332052bec482f211d651ed2f553148e"
+talks:
+- title: "Why podcasts are awesome"
+  speakers:
+    - name: "Thomas Einwaller"
+      img: "//avatars0.githubusercontent.com/u/103224?v=3&s=200"
+- title: "Why Visual Studio is a great web IDE"
+  speakers:
+    - name: "Hannes Sachsenhofer"
+      img: "//avatars2.githubusercontent.com/u/1190606?v=3&s=200"
+- title: "Retrogames"
+  speakers:
+    - name: "Stefan Schraml"
+      img: "//fbcdn-profile-a.akamaihd.net/hprofile-ak-xaf1/t1.0-1/c66.33.407.407/s160x160/319952_2199421196546_1963878823_n.jpg"
+- title: "Google Cloud Endpoints for Android"
+  speakers:
+    - name: "Stephan Schober"
+      img: "//fbcdn-profile-a.akamaihd.net/hprofile-ak-xap1/v/t1.0-1/c0.0.160.160/p160x160/1476474_10201015987223192_1808483175_n.jpg?oh=eb77d585672cef5b3f73b68d23cc367b&oe=54539056&__gda__=1414733406_9332052bec482f211d651ed2f553148e"
 ---

--- a/_plauscherl/20.html
+++ b/_plauscherl/20.html
@@ -19,17 +19,17 @@ location:
   coordinates:
     lat: 48.312657724123234
     lng: 14.2983850772047
-speakers:
--
-  name: Jakob Leitner
-  talk: Interaktive Wand
-  img: //fbcdn-profile-a.akamaihd.net/hprofile-ak-prn2/v/t1.0-1/c53.176.662.662/s160x160/1146567_1400016863557858_996473903_n.jpg?oh=2469a55152336c24760d35625821ca60&oe=546F0042&__gda__=1415870809_c84d34a61c83da5b5ff50862e2f95a62
--
-  name: Lukas Bischof
-  talk: Open Street Map
-  img: //fbcdn-profile-a.akamaihd.net/hprofile-ak-xaf1/t1.0-1/c27.0.160.160/p160x160/207740_10150151070074335_8386304_n.jpg
--
-  name: Stefan Schober
-  talk: Laravel
-  img: //fbcdn-profile-a.akamaihd.net/hprofile-ak-xpf1/t1.0-1/c0.62.155.155/1609655_10202614311231776_1744730968_n.jpg
+talks:
+- title: "Interaktive Wand"
+  speakers:
+    - name: "Jakob Leitner"
+      img: "//fbcdn-profile-a.akamaihd.net/hprofile-ak-prn2/v/t1.0-1/c53.176.662.662/s160x160/1146567_1400016863557858_996473903_n.jpg?oh=2469a55152336c24760d35625821ca60&oe=546F0042&__gda__=1415870809_c84d34a61c83da5b5ff50862e2f95a62"
+- title: "Open Street Map"
+  speakers:
+    - name: "Lukas Bischof"
+      img: "//fbcdn-profile-a.akamaihd.net/hprofile-ak-xaf1/t1.0-1/c27.0.160.160/p160x160/207740_10150151070074335_8386304_n.jpg"
+- title: "Laravel"
+  speakers:
+    - name: "Stefan Schober"
+      img: "//fbcdn-profile-a.akamaihd.net/hprofile-ak-xpf1/t1.0-1/c0.62.155.155/1609655_10202614311231776_1744730968_n.jpg"
 ---

--- a/_plauscherl/21.html
+++ b/_plauscherl/21.html
@@ -18,21 +18,21 @@ location:
   coordinates:
     lat: 48.31900698200975
     lng: 14.30473825105721
-speakers:
--
-  name: Michael Feichtinger
-  talk: "karriere.at - We Love Data"
-  img: //fbcdn-profile-a.akamaihd.net/hprofile-ak-xap1/v/t1.0-1/p160x160/10580258_10203481150204063_4625861252153908536_n.jpg?oh=bc70f9c714c62e8d533bb3b7f64bbe43&oe=5493AF52&__gda__=1417970823_9ff1576b35c91ab4cf7a2685d28c0dd2
--
-  name: "Thomas Pink & Dominik Angerer"
-  talk: REST in Peace
-  img: https://placekitten.com/g/200/200
--
-  name: "Manuel Berger"
-  talk: "Erfahrungen, Tipps & Tricks rund um den Apple AppStore"
-  img: //avatars0.githubusercontent.com/u/1924009
--
-  name: Elisabeth Rosemann
-  talk: PDF Formulare
-  img: //avatars2.githubusercontent.com/u/4456121?v=3&s=460
+talks:
+- title: "karriere.at - We Love Data"
+  speakers:
+    - name: "Michael Feichtinger"
+      img: "//fbcdn-profile-a.akamaihd.net/hprofile-ak-xap1/v/t1.0-1/p160x160/10580258_10203481150204063_4625861252153908536_n.jpg?oh=bc70f9c714c62e8d533bb3b7f64bbe43&oe=5493AF52&__gda__=1417970823_9ff1576b35c91ab4cf7a2685d28c0dd2"
+- title: "REST in Peace"
+  speakers:
+    - name: "Thomas Pink"
+    - name: "Dominik Angerer"
+- title: "Erfahrungen, Tipps & Tricks rund um den Apple AppStore"
+  speakers:
+    - name: "Manuel Berger"
+      img: "//avatars0.githubusercontent.com/u/1924009"
+- title: "PDF Formulare"
+  speakers:
+    - name: "Elisabeth Rosemann"
+      img: "//avatars2.githubusercontent.com/u/4456121?v=3&s=460"
 ---

--- a/_plauscherl/22.html
+++ b/_plauscherl/22.html
@@ -19,19 +19,19 @@ location:
   coordinates:
     lat: 48.312657724123234
     lng: 14.2983850772047
-speakers:
--
-  name: Stefan Baumgartner
-  talk: Yeoman.io
-  img: //avatars3.githubusercontent.com/u/1374451?v=3&s=200
--
-  name: David Brunnthaler
-  talk: ngrok
-  img: //fbcdn-profile-a.akamaihd.net/hprofile-ak-xap1/v/t1.0-1/c66.66.828.828/s160x160/1044923_10200218355882971_1842477700_n.jpg?oh=f3389c08beb47a4a0765892afb81026d&oe=54B656E1&__gda__=1421571984_b13f9f07a43259d911740789bad89c73
--
-  name: Elisabeth Rosemann
-  talk: Intro to Searching (Lucene, elasticsearch, Solr)
-  img: https://fbcdn-profile-a.akamaihd.net/hprofile-ak-xpf1/v/t1.0-1/c40.0.160.160/p160x160/10157300_10152111084257781_1312049397783001435_n.jpg?oh=5fc8526c644dc9cddf118e8d23426d44&oe=54ADB31B&__gda__=1425054782_7780d78d944b5ad08c2225f48f10b1f4
+talks:
+- title: "Yeoman.io"
+  speakers:
+    - name: "Stefan Baumgartner"
+      img: "//avatars3.githubusercontent.com/u/1374451?v=3&s=200"
+- title: "ngrok"
+  speakers:
+    - name: "David Brunnthaler"
+      img: "//fbcdn-profile-a.akamaihd.net/hprofile-ak-xap1/v/t1.0-1/c66.66.828.828/s160x160/1044923_10200218355882971_1842477700_n.jpg?oh=f3389c08beb47a4a0765892afb81026d&oe=54B656E1&__gda__=1421571984_b13f9f07a43259d911740789bad89c73"
+- title: "Intro to Searching (Lucene, elasticsearch, Solr)"
+  speakers:
+    - name: "Elisabeth Rosemann"
+      img: "https://fbcdn-profile-a.akamaihd.net/hprofile-ak-xpf1/v/t1.0-1/c40.0.160.160/p160x160/10157300_10152111084257781_1312049397783001435_n.jpg?oh=5fc8526c644dc9cddf118e8d23426d44&oe=54ADB31B&__gda__=1425054782_7780d78d944b5ad08c2225f48f10b1f4"
 ---
 
 <p>Im Rahmen der Codeweek laden wir die "Next Generation" der Programmierer -- und somit vielleicht auch unsere zukünftigen Kollegen -- zu uns ein.</p>

--- a/_plauscherl/23.html
+++ b/_plauscherl/23.html
@@ -19,19 +19,19 @@ location:
   coordinates:
     lat: 48.310108
     lng: 14.283888
-speakers:
--
-  name: Ralph Mayr
-  talk:  Borland und Vorstellung der Produktpalette
--
-  name: Phil Reither
-  talk:  parse.com und was sonst noch nötig ist um im Outback mit seinem Startup zu überleben
-  img: //avatars2.githubusercontent.com/u/2776512?v=3&s=200
--
-  name: Norbert Kehrer
-  talk: Automatisches Übersetzen von klassischen Arcade-Spielen nach JavaScript
--
-  name: Thomas Fischl
-  talk: Mit Docker in die Cloud - Docker, Cloud, AWS
-  img: //x1.xingassets.com/image/2_8_1_abb002224_8447542_3/thomas-fischl-foto.256x256.jpg
+talks:
+- title: "Borland und Vorstellung der Produktpalette"
+  speakers:
+    - name: "Ralph Mayr"
+- title: "parse.com und was sonst noch nötig ist um im Outback mit seinem Startup zu überleben"
+  speakers:
+    - name: "Phil Reither"
+      img: "//avatars2.githubusercontent.com/u/2776512?v=3&s=200"
+- title: "Automatisches Übersetzen von klassischen Arcade-Spielen nach JavaScript"
+  speakers:
+    - name: "Norbert Kehrer"
+- title: "Mit Docker in die Cloud - Docker, Cloud, AWS"
+  speakers:
+    - name: "Thomas Fischl"
+      img: "//x1.xingassets.com/image/2_8_1_abb002224_8447542_3/thomas-fischl-foto.256x256.jpg"
 ---

--- a/_plauscherl/24.html
+++ b/_plauscherl/24.html
@@ -18,21 +18,21 @@ location:
     lat: 48.303619026937284
     lng: 14.299148350489265
 sponsor: <a href="https://www.cloudflight.io">Catalysts GmbH</a>
-speakers:
--
-  name: Lukas Eder
-  talk:  Get Back in Control of Your SQL with jOOQ
-  img: //pbs.twimg.com/profile_images/443848404058124288/ebesRyrK_400x400.jpeg
--
-  name: Thomas Einwaller
-  talk:  What the version?
-  img: //pbs.twimg.com/profile_images/672150804049076224/-RlNnbGx.jpg
--
-  name: Mike Penz
-  talk:  Open Source
-  img: //avatars3.githubusercontent.com/u/1476232?v=3&s=400
--
-  name: Paul Klingelhuber
-  talk: Cross-browser addons - The manual way
-  img: //i.imgur.com/4qEFc01.jpg
+talks:
+- title: "Get Back in Control of Your SQL with jOOQ"
+  speakers:
+    - name: "Lukas Eder"
+      img: "//pbs.twimg.com/profile_images/443848404058124288/ebesRyrK_400x400.jpeg"
+- title: "What the version?"
+  speakers:
+    - name: "Thomas Einwaller"
+      img: "//pbs.twimg.com/profile_images/672150804049076224/-RlNnbGx.jpg"
+- title: "Open Source"
+  speakers:
+    - name: "Mike Penz"
+      img: "//avatars3.githubusercontent.com/u/1476232?v=3&s=400"
+- title: "Cross-browser addons - The manual way"
+  speakers:
+    - name: "Paul Klingelhuber"
+      img: "//i.imgur.com/4qEFc01.jpg"
 ---

--- a/_plauscherl/25.html
+++ b/_plauscherl/25.html
@@ -18,21 +18,21 @@ location:
   coordinates:
     lat: 48.302047828932714
     lng: 14.287041196763054
-speakers:
--
-  name: Hannes Sachsenhofer
-  talk: Put your CV into CI and CD
-  img: //avatars2.githubusercontent.com/u/1190606
--
-  name: Alexander Feiglstorfer
-  talk: Ecommerce in Brazil
-  img: //avatars0.githubusercontent.com/u/160495
--
-  name: Peter Rietzler
-  talk: "Dealing with Change: 5+ TPDPD"
-  img: /img/speaker-avatars/peter-rietzler.jpg
--
-  name: Michael Tschernuth
-  talk: "Android basics and data synchronization @tractive"
-  img: "//fbcdn-profile-a.akamaihd.net/hprofile-ak-xpf1/v/t1.0-1/p160x160/10300020_10152814930409124_6201298269594145005_n.jpg?oh=67826e2e3a7f95899f6b0a780616505d&oe=55B688AF&__gda__=1433843671_bc0af7d94bc9e283fe70660a17a80e8b"
+talks:
+- title: "Put your CV into CI and CD"
+  speakers:
+    - name: "Hannes Sachsenhofer"
+      img: "//avatars2.githubusercontent.com/u/1190606"
+- title: "Ecommerce in Brazil"
+  speakers:
+    - name: "Alexander Feiglstorfer"
+      img: "//avatars0.githubusercontent.com/u/160495"
+- title: "Dealing with Change: 5+ TPDPD"
+  speakers:
+    - name: "Peter Rietzler"
+      img: "/img/speaker-avatars/peter-rietzler.jpg"
+- title: "Android basics and data synchronization @tractive"
+  speakers:
+    - name: "Michael Tschernuth"
+      img: "//fbcdn-profile-a.akamaihd.net/hprofile-ak-xpf1/v/t1.0-1/p160x160/10300020_10152814930409124_6201298269594145005_n.jpg?oh=67826e2e3a7f95899f6b0a780616505d&oe=55B688AF&__gda__=1433843671_bc0af7d94bc9e283fe70660a17a80e8b"
 ---

--- a/_plauscherl/26.html
+++ b/_plauscherl/26.html
@@ -18,21 +18,21 @@ location:
   coordinates:
     lat: 48.31900698200975
     lng: 14.30473825105721
-speakers:
--
-  name: Franz Seher
-  talk: Service Design Thinking
-  img: https://holis-market.at/wordpress/wp-content/uploads/2015/02/seher-small.png
--
-  name: Alex Hager
-  talk: From Subversion to Git - The End of a Long Journey
-  img: //www.gravatar.com/avatar/c2eaee9928118d41bda09502b2570890.png?s=200
--
-  name: Michael Eisler
-  talk:  Startup Learnings aus meiner Zeit in Kalifornien
-  img: //pbs.twimg.com/profile_images/1259755555/image.jpg
--
-  name: Georg Ringer
-  talk: Sicherheit im Web - Ein Erfahrungsbericht
-  img: //pbs.twimg.com/profile_images/1666247103/6045809013_20f016700c_m_400x400.jpg
+talks:
+- title: "Service Design Thinking"
+  speakers:
+    - name: "Franz Seher"
+      img: "https://holis-market.at/wordpress/wp-content/uploads/2015/02/seher-small.png"
+- title: "From Subversion to Git - The End of a Long Journey"
+  speakers:
+    - name: "Alex Hager"
+      img: "//www.gravatar.com/avatar/c2eaee9928118d41bda09502b2570890.png?s=200"
+- title: "Startup Learnings aus meiner Zeit in Kalifornien"
+  speakers:
+    - name: "Michael Eisler"
+      img: "//pbs.twimg.com/profile_images/1259755555/image.jpg"
+- title: "Sicherheit im Web - Ein Erfahrungsbericht"
+  speakers:
+    - name: "Georg Ringer"
+      img: "//pbs.twimg.com/profile_images/1666247103/6045809013_20f016700c_m_400x400.jpg"
 ---

--- a/_plauscherl/27.html
+++ b/_plauscherl/27.html
@@ -18,22 +18,22 @@ location:
   coordinates:
     lat: 48.3125250952205
     lng: 14.298081718795546
-speakers:
--
-  name: Arno Hütter
-  talk: "The Making of the PC"
-  talklink: https://www.slideshare.net/ArnoHuetter/pc-history
-  img: //avatars.githubusercontent.com/u/13778307
--
-  name: Dominik Angerer
-  talk: your way through the html with java?
-  img: //avatars2.githubusercontent.com/u/7952803?v=3&s=460
--
-  name: Thomas Einwaller
-  talk:  Dockerize everything
-  img: //pbs.twimg.com/profile_images/672150804049076224/-RlNnbGx.jpg
--
-  name: Robert Aistleitner
-  talk: Real-time done in no time
-  img: //avatars1.githubusercontent.com/u/7023117
+talks:
+- title: "The Making of the PC"
+  speakers:
+    - name: "Arno Hütter"
+      img: "//avatars.githubusercontent.com/u/13778307"
+  talklink: "https://www.slideshare.net/ArnoHuetter/pc-history"
+- title: "your way through the html with java?"
+  speakers:
+    - name: "Dominik Angerer"
+      img: "//avatars2.githubusercontent.com/u/7952803?v=3&s=460"
+- title: "Dockerize everything"
+  speakers:
+    - name: "Thomas Einwaller"
+      img: "//pbs.twimg.com/profile_images/672150804049076224/-RlNnbGx.jpg"
+- title: "Real-time done in no time"
+  speakers:
+    - name: "Robert Aistleitner"
+      img: "//avatars1.githubusercontent.com/u/7023117"
 ---

--- a/_plauscherl/28.html
+++ b/_plauscherl/28.html
@@ -18,22 +18,22 @@ location:
   coordinates:
     lat: 48.329348
     lng: 14.3202109
-speakers:
--
-  name: Alex Scheran
-  talk: "Real User eXperience Is Thrilling"
-  img: //i.imgur.com/UortHCO.jpg
--
-  name: Matthias Grimmer
-  talk: "Truffle - One VM to rule them all"
-  img: "//fbcdn-profile-a.akamaihd.net/hprofile-ak-xaf1/v/t1.0-1/p160x160/14611_1013052038709384_2951873812529625325_n.jpg?oh=f0122209ef1046f60cce38341cadfb47&oe=55FE1620&__gda__=1442111383_79bb7a6923060c79f85f45fac8f4b7e6"
--
-  name: Klaus Muckenhuber
-  talk: "Realtime Onsite Marketing"
-  img: "//lh3.googleusercontent.com/-eG34_brncNM/AAAAAAAAAAI/AAAAAAAAAAA/Hx6yjYACCbc/s120-c/photo.jpg"
--
-  name: Bernhard Waldbrunner
-  talk: "Fun with front-end preprocessors"
-  img: "//gravatar.com/avatar/227574aa93f55537a153c76ed4bcdc37?s=200"
+talks:
+- title: "Real User eXperience Is Thrilling"
+  speakers:
+    - name: "Alex Scheran"
+      img: "//i.imgur.com/UortHCO.jpg"
+- title: "Truffle - One VM to rule them all"
+  speakers:
+    - name: "Matthias Grimmer"
+      img: "//fbcdn-profile-a.akamaihd.net/hprofile-ak-xaf1/v/t1.0-1/p160x160/14611_1013052038709384_2951873812529625325_n.jpg?oh=f0122209ef1046f60cce38341cadfb47&oe=55FE1620&__gda__=1442111383_79bb7a6923060c79f85f45fac8f4b7e6"
+- title: "Realtime Onsite Marketing"
+  speakers:
+    - name: "Klaus Muckenhuber"
+      img: "//lh3.googleusercontent.com/-eG34_brncNM/AAAAAAAAAAI/AAAAAAAAAAA/Hx6yjYACCbc/s120-c/photo.jpg"
+- title: "Fun with front-end preprocessors"
+  speakers:
+    - name: "Bernhard Waldbrunner"
+      img: "//gravatar.com/avatar/227574aa93f55537a153c76ed4bcdc37?s=200"
 ---
 

--- a/_plauscherl/29.html
+++ b/_plauscherl/29.html
@@ -18,18 +18,18 @@ location:
   coordinates:
     lat: 48.303619026937284
     lng: 14.299148350489265
-speakers:
--
-  name: Arno Hütter
-  talk: "Software Disasters"
-  talklink: https://www.slideshare.net/ArnoHuetter/software-disasters
-  img: //avatars.githubusercontent.com/u/13778307
--
-  name: Rainer Stropek
-  talk: ".NET auf Linux – die neue CoreCLR"
-  img: //pbs.twimg.com/profile_images/967152604/RainerStropek_Ausschnitt_400x400.JPG
--
-  name: Robert Schmelzer
-  talk: "Software Architecture for Developers"
-  img: //x1.xingassets.com/image/7_3_0_b57234808_3452160_1/robert-schmelzer-foto.256x256.jpg
+talks:
+- title: "Software Disasters"
+  speakers:
+    - name: "Arno Hütter"
+      img: "//avatars.githubusercontent.com/u/13778307"
+  talklink: "https://www.slideshare.net/ArnoHuetter/software-disasters"
+- title: ".NET auf Linux – die neue CoreCLR"
+  speakers:
+    - name: "Rainer Stropek"
+      img: "//pbs.twimg.com/profile_images/967152604/RainerStropek_Ausschnitt_400x400.JPG"
+- title: "Software Architecture for Developers"
+  speakers:
+    - name: "Robert Schmelzer"
+      img: "//x1.xingassets.com/image/7_3_0_b57234808_3452160_1/robert-schmelzer-foto.256x256.jpg"
 ---

--- a/_plauscherl/30.html
+++ b/_plauscherl/30.html
@@ -18,17 +18,17 @@ location:
   coordinates:
     lat: 48.319135072861926
     lng: 14.3081829324964
-speakers:
--
-  name: "Paul Lanzerstorfer"
-  talk: "Using Real Device Clouds for Mobile Test Automation - Challenges and Vendors"
-  img: //imgur.com/TVsLskC.png
--
-  name: Harald Zeitlhofer
-  talk: Neuigkeiten bei NGINX
-  img: //pbs.twimg.com/profile_images/453850359014764544/SQInVT-p.jpeg
--
-  name: David Tanzer
-  talk: "Single Page Webapps mit Clojure und ClojureScript"
-  img: //fbcdn-profile-a.akamaihd.net/hprofile-ak-xaf1/v/t1.0-1/c50.151.621.621/s160x160/312215_174607659291187_222943803_n.jpg?oh=0f990aa1d38775c905313447641aa3ea&oe=56A9857C&__gda__=1449011900_a2a468b9c8e213241cd37081050a515a
+talks:
+- title: "Using Real Device Clouds for Mobile Test Automation - Challenges and Vendors"
+  speakers:
+    - name: "Paul Lanzerstorfer"
+      img: "//imgur.com/TVsLskC.png"
+- title: "Neuigkeiten bei NGINX"
+  speakers:
+    - name: "Harald Zeitlhofer"
+      img: "//pbs.twimg.com/profile_images/453850359014764544/SQInVT-p.jpeg"
+- title: "Single Page Webapps mit Clojure und ClojureScript"
+  speakers:
+    - name: "David Tanzer"
+      img: "//fbcdn-profile-a.akamaihd.net/hprofile-ak-xaf1/v/t1.0-1/c50.151.621.621/s160x160/312215_174607659291187_222943803_n.jpg?oh=0f990aa1d38775c905313447641aa3ea&oe=56A9857C&__gda__=1449011900_a2a468b9c8e213241cd37081050a515a"
 ---

--- a/_plauscherl/31.html
+++ b/_plauscherl/31.html
@@ -18,16 +18,16 @@ location:
   coordinates:
     lat: 48.31740267577672
     lng: 14.287293889562443
-speakers:
--
-  name: "Hubert Ströbitzer"
-  talk: "Apache Camel"
-  img: //x1.xingassets.com/image/e_5_5_7a23867eb_17792974_4/hubert-str%C3%B6bitzer-foto.256x256.jpg
--
-  name: Norbert Kehrer
-  talk: Neue Sichtweisen auf das Retro-Autorennspiel Sprint
--
-  name: Jakob Schröger
-  talk: Speedbreaker oder Sprungbrett? Herausforderungen für Startups
-  img: //media.licdn.com/mpr/mpr/shrinknp_400_400/p/3/005/03f/235/1a53d90.jpg
+talks:
+- title: "Apache Camel"
+  speakers:
+    - name: "Hubert Ströbitzer"
+      img: "//x1.xingassets.com/image/e_5_5_7a23867eb_17792974_4/hubert-str%C3%B6bitzer-foto.256x256.jpg"
+- title: "Neue Sichtweisen auf das Retro-Autorennspiel Sprint"
+  speakers:
+    - name: "Norbert Kehrer"
+- title: "Speedbreaker oder Sprungbrett? Herausforderungen für Startups"
+  speakers:
+    - name: "Jakob Schröger"
+      img: "//media.licdn.com/mpr/mpr/shrinknp_400_400/p/3/005/03f/235/1a53d90.jpg"
 ---

--- a/_plauscherl/32.html
+++ b/_plauscherl/32.html
@@ -17,18 +17,18 @@ location:
   coordinates:
     lat: 48.30651606176941
     lng: 14.287391220235042
-speakers:
--
-  name: René Pirringer
-  talk: "RGB-LED Strip Streuerung mit Arduino, BLE und iPhone"
-  img: https://ciqua.com/images/photos/RP.jpg
--
-  name: Arno Hütter
-  talk: "Low-Level Windows Debugging mit WinDbg"
-  talklink: https://de.slideshare.net/ArnoHuetter/windows-debugging-with-windbg
-  img: //avatars.githubusercontent.com/u/13778307
--
-  name: Gregor Multerberger
-  talk: "Server/Application Monitoring mit Zabbix"
-  img: //scontent-frt3-1.xx.fbcdn.net/hprofile-xpa1/v/t1.0-1/p160x160/12115733_1056301857723090_955067315156588742_n.jpg?oh=a025e7466520f3073eb99b7b7dcba8b4&oe=56ED4440
+talks:
+- title: "RGB-LED Strip Streuerung mit Arduino, BLE und iPhone"
+  speakers:
+    - name: "René Pirringer"
+      img: "https://ciqua.com/images/photos/RP.jpg"
+- title: "Low-Level Windows Debugging mit WinDbg"
+  speakers:
+    - name: "Arno Hütter"
+      img: "//avatars.githubusercontent.com/u/13778307"
+  talklink: "https://de.slideshare.net/ArnoHuetter/windows-debugging-with-windbg"
+- title: "Server/Application Monitoring mit Zabbix"
+  speakers:
+    - name: "Gregor Multerberger"
+      img: "//scontent-frt3-1.xx.fbcdn.net/hprofile-xpa1/v/t1.0-1/p160x160/12115733_1056301857723090_955067315156588742_n.jpg?oh=a025e7466520f3073eb99b7b7dcba8b4&oe=56ED4440"
 ---

--- a/_plauscherl/33.html
+++ b/_plauscherl/33.html
@@ -18,23 +18,23 @@ location:
   coordinates:
     lat: 48.302047828932714
     lng: 14.287041196763054
-speakers:
--
-  name: Paul Lanzerstorfer
-  talk: The State of "Agile" - Resümee zur Agile Tour Vienna 2015
-  img: //scontent.xx.fbcdn.net/hprofile-prn2/v/t1.0-1/c0.133.640.640/10405630_10202653300478438_3654843520497113818_n.jpg?oh=d6db9d25860f614d33ceadeb43665cd5&oe=57475771
--
-  name: Thomas Kaiser
-  talk: Why Scala is the Better Java
-  talklink: https://de.slideshare.net/ThomasKaiser6/why-scala-is-the-better-java
-  img: //scontent.xx.fbcdn.net/hprofile-xtp1/v/t1.0-1/p160x160/11144910_1006309982714853_1053269170351467437_n.jpg?oh=e02bba72fb75cebd63f1137ed9e4bf9f&oe=5745075A
--
-  name: Gergö Kalapos
-  talk: The Universal Windows Platform (UWP)
-  talklink: https://kalapos.azurewebsites.net/Media/Default/Slides/GergelyKalapos_UWP.pptx
-  img: //scontent-frt3-1.xx.fbcdn.net/hprofile-xfa1/v/t1.0-1/c2.0.160.160/p160x160/10440963_10203268907794892_4196136761228292623_n.jpg?oh=1e780579a2ba533b3036b887d10751c9&oe=5703EE57
--
-  name: Günther Grill
-  talk: Apache Spark
-  img: //lh3.googleusercontent.com/-fPA7PzLw7f8/Vo40lpJoHvI/AAAAAAAACDU/JIRPqZPC81Y/w140-h139-p/Guenther_comic.png
+talks:
+- title: "The State of \"Agile\" - Resümee zur Agile Tour Vienna 2015"
+  speakers:
+    - name: "Paul Lanzerstorfer"
+      img: "//scontent.xx.fbcdn.net/hprofile-prn2/v/t1.0-1/c0.133.640.640/10405630_10202653300478438_3654843520497113818_n.jpg?oh=d6db9d25860f614d33ceadeb43665cd5&oe=57475771"
+- title: "Why Scala is the Better Java"
+  speakers:
+    - name: "Thomas Kaiser"
+      img: "//scontent.xx.fbcdn.net/hprofile-xtp1/v/t1.0-1/p160x160/11144910_1006309982714853_1053269170351467437_n.jpg?oh=e02bba72fb75cebd63f1137ed9e4bf9f&oe=5745075A"
+  talklink: "https://de.slideshare.net/ThomasKaiser6/why-scala-is-the-better-java"
+- title: "The Universal Windows Platform (UWP)"
+  speakers:
+    - name: "Gergö Kalapos"
+      img: "//scontent-frt3-1.xx.fbcdn.net/hprofile-xfa1/v/t1.0-1/c2.0.160.160/p160x160/10440963_10203268907794892_4196136761228292623_n.jpg?oh=1e780579a2ba533b3036b887d10751c9&oe=5703EE57"
+  talklink: "https://kalapos.azurewebsites.net/Media/Default/Slides/GergelyKalapos_UWP.pptx"
+- title: "Apache Spark"
+  speakers:
+    - name: "Günther Grill"
+      img: "//lh3.googleusercontent.com/-fPA7PzLw7f8/Vo40lpJoHvI/AAAAAAAACDU/JIRPqZPC81Y/w140-h139-p/Guenther_comic.png"
 ---

--- a/_plauscherl/34.html
+++ b/_plauscherl/34.html
@@ -18,21 +18,21 @@ location:
   coordinates:
     lat: 48.31900698200975
     lng: 14.30473825105721
-speakers:
--
-  name: Andreas Gruber
-  talk: Turning Mozillas PDF.js into a Collaborative PDF annotation service
-  img: //media.licdn.com/mpr/mpr/shrinknp_400_400/p/2/005/029/3c2/372319d.jpg
--
-  name: Thomas Fischl
-  talk: "Lesson Learned: Entwickler in einem Startup"
-  img: //x1.xingassets.com/image/2_8_1_abb002224_8447542_3/thomas-fischl-foto.256x256.jpg
--
-  name: Klemens Gordon	
-  talk: "Webpack ftw - karriere.at application bundling now and then"
-  img: //pbs.twimg.com/profile_images/694425461313638400/fjGj1QjB_400x400.jpg
--
-  name: Rainer Stropek
-  talk: "TypeScript"
-  img: //pbs.twimg.com/profile_images/967152604/RainerStropek_Ausschnitt_400x400.JPG
+talks:
+- title: "Turning Mozillas PDF.js into a Collaborative PDF annotation service"
+  speakers:
+    - name: "Andreas Gruber"
+      img: "//media.licdn.com/mpr/mpr/shrinknp_400_400/p/2/005/029/3c2/372319d.jpg"
+- title: "Lesson Learned: Entwickler in einem Startup"
+  speakers:
+    - name: "Thomas Fischl"
+      img: "//x1.xingassets.com/image/2_8_1_abb002224_8447542_3/thomas-fischl-foto.256x256.jpg"
+- title: "Webpack ftw - karriere.at application bundling now and then"
+  speakers:
+    - name: "Klemens Gordon"
+      img: "//pbs.twimg.com/profile_images/694425461313638400/fjGj1QjB_400x400.jpg"
+- title: "TypeScript"
+  speakers:
+    - name: "Rainer Stropek"
+      img: "//pbs.twimg.com/profile_images/967152604/RainerStropek_Ausschnitt_400x400.JPG"
 ---

--- a/_plauscherl/35.html
+++ b/_plauscherl/35.html
@@ -18,17 +18,17 @@ location:
   coordinates:
     lat: 48.315
     lng: 14.303
-speakers:
--
-  name: Frederic Köberl
-  talk: How I managed to piss off Ö3
-  img: //scontent-vie1-1.xx.fbcdn.net/hprofile-xtl1/v/t1.0-1/p160x160/1915541_720229834783504_4360391494171749534_n.jpg?oh=708aa6a9cca9b3d8f2d7bce2fb6eae0d&oe=574F1A3B
--
-  name: Thomas Einwaller
-  talk:  Why Slack is not your usual messenger
-  img: //pbs.twimg.com/profile_images/672150804049076224/-RlNnbGx.jpg
--
-  name: Wolfgang Kerschbaumer
-  talk: Make the Web Fast Again!
-  img: //www.cyberhouse.at/wke/wke.jpg
+talks:
+- title: "How I managed to piss off Ö3"
+  speakers:
+    - name: "Frederic Köberl"
+      img: "//scontent-vie1-1.xx.fbcdn.net/hprofile-xtl1/v/t1.0-1/p160x160/1915541_720229834783504_4360391494171749534_n.jpg?oh=708aa6a9cca9b3d8f2d7bce2fb6eae0d&oe=574F1A3B"
+- title: "Why Slack is not your usual messenger"
+  speakers:
+    - name: "Thomas Einwaller"
+      img: "//pbs.twimg.com/profile_images/672150804049076224/-RlNnbGx.jpg"
+- title: "Make the Web Fast Again!"
+  speakers:
+    - name: "Wolfgang Kerschbaumer"
+      img: "//www.cyberhouse.at/wke/wke.jpg"
 ---

--- a/_plauscherl/36.html
+++ b/_plauscherl/36.html
@@ -17,18 +17,20 @@ location:
   coordinates:
     lat: 48.313517
     lng: 14.312948
-speakers:
--
-  name: Arno Hütter
-  talk: "Database performance tuning: A report from the trenches"
-  talklink: https://www.slideshare.net/ArnoHuetter/database-performance-tuning
-  img: //avatars.githubusercontent.com/u/13778307
--
-  name: "Phil Reither & Jason Tevnan & Emmanuel Helm"
-  talk: "Science + Cooking = ♥"
-  img: //avatars2.githubusercontent.com/u/2776512?v=3&s=200
--
-  name: "Thomas Peham"
-  talk: "The State of Client Collaboration"
-  img: //pbs.twimg.com/profile_images/697698619273650176/0dlFqg41.jpg
+talks:
+- title: "Database performance tuning: A report from the trenches"
+  speakers:
+    - name: "Arno Hütter"
+      img: "//avatars.githubusercontent.com/u/13778307"
+  talklink: "https://www.slideshare.net/ArnoHuetter/database-performance-tuning"
+- title: "Science + Cooking = ♥"
+  speakers:
+    - name: "Phil Reither"
+      img: "//avatars2.githubusercontent.com/u/2776512?v=3&s=200"
+    - name: "Jason Tevnan"
+    - name: "Emmanuel Helm"
+- title: "The State of Client Collaboration"
+  speakers:
+    - name: "Thomas Peham"
+      img: "//pbs.twimg.com/profile_images/697698619273650176/0dlFqg41.jpg"
 ---

--- a/_plauscherl/37.html
+++ b/_plauscherl/37.html
@@ -18,17 +18,17 @@ location:
   coordinates:
     lat: 48.30135543411172
     lng: 14.294128251141789
-speakers:
--
-  name: "Johann Hubert Sonntagbauer"
-  talk: "Progressive Web Apps"
-  img: https://raw.githubusercontent.com/technologieplauscherl/technologieplauscherl.github.io/master/img/speaker-avatars/johann_hubert_sonntagbauer.jpeg
--
-  name: "Christoph Strobl"
-  talk: "Hypermedia-Driven RESTful APIs"
-  img: //pbs.twimg.com/profile_images/443764401510694912/udyDMcNb.png
--
-  name: "Paul Lanzerstorfer"
-  talk: "The World with Self-Driving Cars"
-  img: //dl.dropboxusercontent.com/u/5061139/Paul.jpg
+talks:
+- title: "Progressive Web Apps"
+  speakers:
+    - name: "Johann Hubert Sonntagbauer"
+      img: "https://raw.githubusercontent.com/technologieplauscherl/technologieplauscherl.github.io/master/img/speaker-avatars/johann_hubert_sonntagbauer.jpeg"
+- title: "Hypermedia-Driven RESTful APIs"
+  speakers:
+    - name: "Christoph Strobl"
+      img: "//pbs.twimg.com/profile_images/443764401510694912/udyDMcNb.png"
+- title: "The World with Self-Driving Cars"
+  speakers:
+    - name: "Paul Lanzerstorfer"
+      img: "//dl.dropboxusercontent.com/u/5061139/Paul.jpg"
 ---

--- a/_plauscherl/38.html
+++ b/_plauscherl/38.html
@@ -19,17 +19,17 @@ location:
   coordinates:
     lat: 48.302047828932714
     lng: 14.287041196763054
-speakers:
--
-  name: Günther Grill
-  talk: Apache Cassandra Basics
-  img: //lh3.googleusercontent.com/-fPA7PzLw7f8/Vo40lpJoHvI/AAAAAAAACDU/JIRPqZPC81Y/w140-h139-p/Guenther_comic.png
--
-  name: Christian Danner
-  talk: Clientseitige Übersetzung von Websites
-  img: //www.xing.com/image/1_2_d_3cffc114e_8759227_7/christian-danner-foto.1024x1024.jpg
--
-  name: David Tanzer
-  talk: Evolutionäres Softwaredesign mit TDD
-  img: //www.davidtanzer.net/download/foto_david.jpg
+talks:
+- title: "Apache Cassandra Basics"
+  speakers:
+    - name: "Günther Grill"
+      img: "//lh3.googleusercontent.com/-fPA7PzLw7f8/Vo40lpJoHvI/AAAAAAAACDU/JIRPqZPC81Y/w140-h139-p/Guenther_comic.png"
+- title: "Clientseitige Übersetzung von Websites"
+  speakers:
+    - name: "Christian Danner"
+      img: "//www.xing.com/image/1_2_d_3cffc114e_8759227_7/christian-danner-foto.1024x1024.jpg"
+- title: "Evolutionäres Softwaredesign mit TDD"
+  speakers:
+    - name: "David Tanzer"
+      img: "//www.davidtanzer.net/download/foto_david.jpg"
 ---

--- a/_plauscherl/39.html
+++ b/_plauscherl/39.html
@@ -21,19 +21,19 @@ location:
   coordinates:
     lat: 48.31267596623281
     lng: 14.298395297041242
-speakers:
--
-  name: Dirk Wallerstorfer
-  talk: DevOps Guide to Container Networking (en)
-  talklink: https://www.slideshare.net/DirkWallerstorfer/devops-guide-to-container-networking-62858097
-  img: //d3fzhvprqmsab7.cloudfront.net/wp-content/uploads/2016/05/dirk_800-150x150.png
--
-  name: Michael Lanzinger
-  talk: Haftungspflichten im Web
-  talklink: https://de.slideshare.net/MichaelLanzinger/haftung-im-web
-  img: //scontent.xx.fbcdn.net/v/t1.0-1/c0.0.160.160/p160x160/11200639_1764156163854831_4829798571866319096_n.jpg?oh=84733b766fe67381f3889277290d3b8c&oe=57F4AC0A
--
-  name: Robert Schmelzer
-  talk: Was so alles schief gehen kann ... und andere Anekdoten aus dem Betrieb
-  img: //scontent-vie1-1.xx.fbcdn.net/v/t1.0-9/10262151_10152245771438375_7745088332052116410_n.jpg?oh=15d24b21fcc7b701af23c0845fa743cb&oe=58296DA1
+talks:
+- title: "DevOps Guide to Container Networking (en)"
+  speakers:
+    - name: "Dirk Wallerstorfer"
+      img: "//d3fzhvprqmsab7.cloudfront.net/wp-content/uploads/2016/05/dirk_800-150x150.png"
+  talklink: "https://www.slideshare.net/DirkWallerstorfer/devops-guide-to-container-networking-62858097"
+- title: "Haftungspflichten im Web"
+  speakers:
+    - name: "Michael Lanzinger"
+      img: "//scontent.xx.fbcdn.net/v/t1.0-1/c0.0.160.160/p160x160/11200639_1764156163854831_4829798571866319096_n.jpg?oh=84733b766fe67381f3889277290d3b8c&oe=57F4AC0A"
+  talklink: "https://de.slideshare.net/MichaelLanzinger/haftung-im-web"
+- title: "Was so alles schief gehen kann ... und andere Anekdoten aus dem Betrieb"
+  speakers:
+    - name: "Robert Schmelzer"
+      img: "//scontent-vie1-1.xx.fbcdn.net/v/t1.0-9/10262151_10152245771438375_7745088332052116410_n.jpg?oh=15d24b21fcc7b701af23c0845fa743cb&oe=58296DA1"
 ---

--- a/_plauscherl/40.html
+++ b/_plauscherl/40.html
@@ -20,18 +20,18 @@ location:
   coordinates:
     lat: 48.24086531900188
     lng: 14.234195755222851
-speakers:
--
-  name: Matthias Grimmer
-  talk: Dynamic compilation of SELF
-  img: //pbs.twimg.com/profile_images/618340342174253056/VoF-Ga6i_400x400.jpg
--
-  name: Michael Hurnaus
-  talk: Why I quit my dream job to found a startup. - Things to know when founding a startup
-  img: //scontent-vie1-1.xx.fbcdn.net/v/t1.0-1/p160x160/1463085_10151847745278246_473952397_n.jpg?oh=3bea507e021397f2a4dccf5d21d86069&oe=58183B88
--
-  name: Christoph Strobl
-  talk: Redis 3.0
-  talklink: https://www.slideshare.net/SpringCentral/next-level-redis-with-spring
-  img: //pbs.twimg.com/profile_images/443764401510694912/udyDMcNb.png
+talks:
+- title: "Dynamic compilation of SELF"
+  speakers:
+    - name: "Matthias Grimmer"
+      img: "//pbs.twimg.com/profile_images/618340342174253056/VoF-Ga6i_400x400.jpg"
+- title: "Why I quit my dream job to found a startup. - Things to know when founding a startup"
+  speakers:
+    - name: "Michael Hurnaus"
+      img: "//scontent-vie1-1.xx.fbcdn.net/v/t1.0-1/p160x160/1463085_10151847745278246_473952397_n.jpg?oh=3bea507e021397f2a4dccf5d21d86069&oe=58183B88"
+- title: "Redis 3.0"
+  speakers:
+    - name: "Christoph Strobl"
+      img: "//pbs.twimg.com/profile_images/443764401510694912/udyDMcNb.png"
+  talklink: "https://www.slideshare.net/SpringCentral/next-level-redis-with-spring"
 ---

--- a/_plauscherl/41.html
+++ b/_plauscherl/41.html
@@ -25,20 +25,20 @@ location:
     lat: 48.3352289652234
     lng: 14.324333373333957
 sponsor: <a href="https://www.xxxlutz.at">XXXLutz</a>
-speakers:
--
-  name: Alexander Möslinger-Neundlinger
-  talk: How to excite customers - Why Usability is not enough!
-  talklink: https://www.facebook.com/groups/technologie.plauscherl/1105400426223196/
-  img:  /img/speaker-avatars/alexander_moeslinger_neundlinger.jpg
--
-  name: Philipp Lengauer
-  talk: Make Memory Monitoring Great Again
-  talklink: https://www.facebook.com/groups/technologie.plauscherl/1105401196223119/
-  img: /img/speaker-avatars/philipp_lengauer.jpeg
--
-  name: Phil Reither
-  talk: It’s all about the $$$
-  talklink: https://gist.github.com/filR/9b8f5592bd5e99624670b12d3acf83b3
-  img: //avatars2.githubusercontent.com/u/2776512?v=3&s=200
+talks:
+- title: "How to excite customers - Why Usability is not enough!"
+  speakers:
+    - name: "Alexander Möslinger-Neundlinger"
+      img: "/img/speaker-avatars/alexander_moeslinger_neundlinger.jpg"
+  talklink: "https://www.facebook.com/groups/technologie.plauscherl/1105400426223196/"
+- title: "Make Memory Monitoring Great Again"
+  speakers:
+    - name: "Philipp Lengauer"
+      img: "/img/speaker-avatars/philipp_lengauer.jpeg"
+  talklink: "https://www.facebook.com/groups/technologie.plauscherl/1105401196223119/"
+- title: "It’s all about the $$$"
+  speakers:
+    - name: "Phil Reither"
+      img: "//avatars2.githubusercontent.com/u/2776512?v=3&s=200"
+  talklink: "https://gist.github.com/filR/9b8f5592bd5e99624670b12d3acf83b3"
 ---

--- a/_plauscherl/42.html
+++ b/_plauscherl/42.html
@@ -23,18 +23,18 @@ location:
     lat: 48.317396566195676
     lng: 14.287229390968763
 sponsor: <a href="https://www.software-quality-lab.com/">Software Quality Lab GmbH</a>
-speakers:
--
-  name: Arno Hütter
-  talk: Programming Legends
-  talklink: https://www.slideshare.net/ArnoHuetter/rockstar-programmers
-  img: //www.xing.com/image/7_8_f_ce1ad0d6e_11379654_20/arno-h%C3%BCtter-foto.1024x1024.jpg
--
-  name: Johannes Hochrainer
-  talk: Kontinuierliche Architekturanalyse
-  img: //www.xing.com/image/8_1_e_80cefb8ca_10020219_10/johannes-hochrainer-foto.256x256.jpg
-- 
-  name: David Tanzer
-  talk: The 4 Rules of Simple Design
-  img: /img/speaker-avatars/david_tanzer.jpg
+talks:
+- title: "Programming Legends"
+  speakers:
+    - name: "Arno Hütter"
+      img: "//www.xing.com/image/7_8_f_ce1ad0d6e_11379654_20/arno-h%C3%BCtter-foto.1024x1024.jpg"
+  talklink: "https://www.slideshare.net/ArnoHuetter/rockstar-programmers"
+- title: "Kontinuierliche Architekturanalyse"
+  speakers:
+    - name: "Johannes Hochrainer"
+      img: "//www.xing.com/image/8_1_e_80cefb8ca_10020219_10/johannes-hochrainer-foto.256x256.jpg"
+- title: "The 4 Rules of Simple Design"
+  speakers:
+    - name: "David Tanzer"
+      img: "/img/speaker-avatars/david_tanzer.jpg"
 ---

--- a/_plauscherl/43.html
+++ b/_plauscherl/43.html
@@ -21,17 +21,17 @@ location:
     lat: 48.31900698200975
     lng: 14.30473825105721
 sponsor: <a href="https://www.karriere.at/">karriere.at</a>
-speakers:
--
-  name: Sharon Foschum
-  talk: Nightwatch.js live coding
-  img: //kcdn.at/employees/sharon.foschum.jpg
--
-  name: René Pirringer
-  talk: Continuous Delivery mit Go.cd
-  img: //ciqua.com/images/photos/RP.jpg
--
-  name: Stefan Baumgartner
-  talk: Technical Writing
-  img: //avatars3.githubusercontent.com/u/1374451?v=3&s=200
+talks:
+- title: "Nightwatch.js live coding"
+  speakers:
+    - name: "Sharon Foschum"
+      img: "//kcdn.at/employees/sharon.foschum.jpg"
+- title: "Continuous Delivery mit Go.cd"
+  speakers:
+    - name: "René Pirringer"
+      img: "//ciqua.com/images/photos/RP.jpg"
+- title: "Technical Writing"
+  speakers:
+    - name: "Stefan Baumgartner"
+      img: "//avatars3.githubusercontent.com/u/1374451?v=3&s=200"
 ---

--- a/_plauscherl/44.html
+++ b/_plauscherl/44.html
@@ -20,16 +20,16 @@ location:
     lat: 48.329348
     lng: 14.3202109
 sponsor: <a href="https://jobs.dynatrace.at/">Dynatrace</a>
-speakers:
--
-  name: Daniel Khan
-  talk: 17 years as a developer
-  img: //nodeconf.risingstack.com/assets/photos/speakers/daniel_khan.jpeg
--
-  name: Matthias Braun
-  talk: The Holy Grail (Scala, Scala.js)
-  img: //www.xing.com/image/b_5_1_e15ade5ab_14291982_4/matthias-braun-foto.256x256.jpg
--
-  name: Andreas Kreuzer
-  talk: Hobbybrauen
+talks:
+- title: "17 years as a developer"
+  speakers:
+    - name: "Daniel Khan"
+      img: "//nodeconf.risingstack.com/assets/photos/speakers/daniel_khan.jpeg"
+- title: "The Holy Grail (Scala, Scala.js)"
+  speakers:
+    - name: "Matthias Braun"
+      img: "//www.xing.com/image/b_5_1_e15ade5ab_14291982_4/matthias-braun-foto.256x256.jpg"
+- title: "Hobbybrauen"
+  speakers:
+    - name: "Andreas Kreuzer"
 ---

--- a/_plauscherl/45.html
+++ b/_plauscherl/45.html
@@ -21,17 +21,17 @@ location:
     lat: 48.302047828932714
     lng: 14.287041196763054
 sponsor: <a href="https://smarter-ecommerce.com/de/unternehmen/#arbeiten-bei-smec">Smarter Ecommerce</a>
-speakers:
--
-  name: Günther Grill
-  talk: WAT! - Java, C# and friends
-  img: //lh3.googleusercontent.com/-fPA7PzLw7f8/Vo40lpJoHvI/AAAAAAAACDU/JIRPqZPC81Y/w140-h139-p/Guenther_comic.png
--
-  name: Manuel Berger
-  talk: How to embed an image? #Web #performance #HTML #2017
-  img: //www.xing.com/image/3_5_c_84c9e3fe3_9031618_11/manuel-berger-foto.256x256.jpg
--
-  name: Anna Völkl
-  talk: Magento Security Best Practises
-  img: //avatars2.githubusercontent.com/u/1798594?v=3&s=200
+talks:
+- title: "WAT! - Java, C# and friends"
+  speakers:
+    - name: "Günther Grill"
+      img: "//lh3.googleusercontent.com/-fPA7PzLw7f8/Vo40lpJoHvI/AAAAAAAACDU/JIRPqZPC81Y/w140-h139-p/Guenther_comic.png"
+- title: "How to embed an image? #Web #performance #HTML #2017"
+  speakers:
+    - name: "Manuel Berger"
+      img: "//www.xing.com/image/3_5_c_84c9e3fe3_9031618_11/manuel-berger-foto.256x256.jpg"
+- title: "Magento Security Best Practises"
+  speakers:
+    - name: "Anna Völkl"
+      img: "//avatars2.githubusercontent.com/u/1798594?v=3&s=200"
 ---

--- a/_plauscherl/46.html
+++ b/_plauscherl/46.html
@@ -20,17 +20,17 @@ location:
     lat: 48.29088256307852
     lng: 14.288329320379118
 sponsor: <a href="https://www.celum.com/career/">Celum</a>
-speakers:
--
-  name: Alexander Fried
-  talk: "Reactive Architecture with Graph Database"
-  img: https://i.imgur.com/2gOAIFN.jpg
--
-  name: Phil Reither
-  talk: "Remote Work: am Strand coden oder doch im Keller vereinsamen?"
-  img: //avatars2.githubusercontent.com/u/2776512?v=3&s=200
--
-  name: Martin Weber
-  talk: "Alexa for Developers"
-  img: //avatars0.githubusercontent.com/u/7472943?v=3&s=200
+talks:
+- title: "Reactive Architecture with Graph Database"
+  speakers:
+    - name: "Alexander Fried"
+      img: "https://i.imgur.com/2gOAIFN.jpg"
+- title: "Remote Work: am Strand coden oder doch im Keller vereinsamen?"
+  speakers:
+    - name: "Phil Reither"
+      img: "//avatars2.githubusercontent.com/u/2776512?v=3&s=200"
+- title: "Alexa for Developers"
+  speakers:
+    - name: "Martin Weber"
+      img: "//avatars0.githubusercontent.com/u/7472943?v=3&s=200"
 ---

--- a/_plauscherl/47.html
+++ b/_plauscherl/47.html
@@ -20,17 +20,17 @@ location:
     lat: 48.317307
     lng: 14.287531
 sponsor: <a href="https://dataformers.at/">dataformers GmbH</a>
-speakers:
--
-  name: Sebastian Gierlinger
-  talk: "The bloody reality when using Docker in production ☠️"
-  img: //scontent-vie1-1.xx.fbcdn.net/v/t1.0-9/155313_1615197332601_6208593_n.jpg?oh=cc321dff0c315ebced89392e19d6042e&oe=598C52CA
--
-  name: Michael Lanzinger
-  talk: "Freie Lizenzen & 3D-Druck"
-  img: //scontent-vie1-1.xx.fbcdn.net/v/t31.0-8/10549233_100243160353470_854487755960959944_o.jpg?oh=02dcc2662cd218092b7893db93f41653&oe=598EBA09
--
-  name: Wilfried Mausz
-  talk: "Redis"
-  img: "/img/speaker-avatars/2017-05-18 speaker wilfried mausz.jpg"
+talks:
+- title: "The bloody reality when using Docker in production ☠️"
+  speakers:
+    - name: "Sebastian Gierlinger"
+      img: "//scontent-vie1-1.xx.fbcdn.net/v/t1.0-9/155313_1615197332601_6208593_n.jpg?oh=cc321dff0c315ebced89392e19d6042e&oe=598C52CA"
+- title: "Freie Lizenzen & 3D-Druck"
+  speakers:
+    - name: "Michael Lanzinger"
+      img: "//scontent-vie1-1.xx.fbcdn.net/v/t31.0-8/10549233_100243160353470_854487755960959944_o.jpg?oh=02dcc2662cd218092b7893db93f41653&oe=598EBA09"
+- title: "Redis"
+  speakers:
+    - name: "Wilfried Mausz"
+      img: "/img/speaker-avatars/2017-05-18 speaker wilfried mausz.jpg"
 ---

--- a/_plauscherl/48.html
+++ b/_plauscherl/48.html
@@ -20,16 +20,16 @@ location:
     lat: 48.311528820218
     lng: 14.298892558880054
 sponsor: <a href="https://startup300.at/">startup300</a>
-speakers:
--
-  name: Christian Kaar
-  talk: "OKRs for Agile Teams: A perfect combination"
-  img:  "/img/speaker-avatars/christian-kaar.jpeg"
--
-  name: Andreas Stürmer
-  talk: "DNA, just an other programming language"
--
-  name: Frederic Köberl
-  talk: "Hacker hassen diese Tricks.<br>Ein Guide zum Schutz gegen Cyberkriminalität."
-  img:  //cdn.internetztube.net/images/static/fred.jpg
+talks:
+- title: "OKRs for Agile Teams: A perfect combination"
+  speakers:
+    - name: "Christian Kaar"
+      img: "/img/speaker-avatars/christian-kaar.jpeg"
+- title: "DNA, just an other programming language"
+  speakers:
+    - name: "Andreas Stürmer"
+- title: "Hacker hassen diese Tricks.<br>Ein Guide zum Schutz gegen Cyberkriminalität."
+  speakers:
+    - name: "Frederic Köberl"
+      img: "//cdn.internetztube.net/images/static/fred.jpg"
 ---

--- a/_plauscherl/49.html
+++ b/_plauscherl/49.html
@@ -20,16 +20,18 @@ location:
     lat: 48.31727531132974
     lng: 14.28834788234948
 sponsor: <a href="https://www.keba.com">KEBA</a>
-speakers:
--
-  name: Shahab Daban, Wolfgang Schreiner
-  talk: "Log Analysis and Predictive Maintenance with Elastic Stack"
-  img:  //www.xing.com/image/e_c_a_c11bed778_16868670_2/shahab-daban-foto.256x256.jpg
--
-  name: Christoph Strobl
-  talk: "Reactive Programming mit Project Reactor / Spring Data / Spring Web Flux"
-  img:  //pbs.twimg.com/profile_images/443764401510694912/udyDMcNb.png
--
-  name: Michael Aufreiter, Oliver Buchtala
-  talk: "Stencila: The Open Office Suite for Reproducible Research"
+talks:
+- title: "Log Analysis and Predictive Maintenance with Elastic Stack"
+  speakers:
+    - name: "Shahab Daban"
+      img: "//www.xing.com/image/e_c_a_c11bed778_16868670_2/shahab-daban-foto.256x256.jpg"
+    - name : "Wolfgang Schreiner"
+- title: "Reactive Programming mit Project Reactor / Spring Data / Spring Web Flux"
+  speakers:
+    - name: "Christoph Strobl"
+      img: "//pbs.twimg.com/profile_images/443764401510694912/udyDMcNb.png"
+- title: "Stencila: The Open Office Suite for Reproducible Research"
+  speakers:
+    - name: "Michael Aufreiter"
+    - name: "Oliver Buchtala"
 ---

--- a/_plauscherl/50.html
+++ b/_plauscherl/50.html
@@ -20,17 +20,17 @@ location:
     lat: 48.31269338541015
     lng: 14.298637541788183
 sponsor: <a href="https://www.storyblok.com">Storyblok</a>
-speakers:
--
-  name: Alexander Feiglstorfer
-  talk: "Pagespeed Stuff"
-  img:  //avatars0.githubusercontent.com/u/160495
--
-  name: Paul Klingelhuber
-  talk: "A Programmer’s Guide to Sound and Music"
-  img:  //i.imgur.com/CpRMOEs.jpg
--
-  name: Das Plauscherl
-  talk: "History of the Plauscherl"
-  img:  /img/icons/apple-touch-icon-120x120.png
+talks:
+- title: "Pagespeed Stuff"
+  speakers:
+    - name: "Alexander Feiglstorfer"
+      img: "//avatars0.githubusercontent.com/u/160495"
+- title: "A Programmer’s Guide to Sound and Music"
+  speakers:
+    - name: "Paul Klingelhuber"
+      img: "//i.imgur.com/CpRMOEs.jpg"
+- title: "History of the Plauscherl"
+  speakers:
+    - name: "Das Plauscherl"
+      img: "/img/icons/apple-touch-icon-120x120.png"
 ---

--- a/_plauscherl/51.html
+++ b/_plauscherl/51.html
@@ -20,17 +20,17 @@ location:
     lat: 48.243419
     lng: 14.236858
 sponsor: <a href="https://www.runtastic.at">Runtastic</a>
-speakers:
--
-  name: Armin Deliomini
-  talk: "Infrastructure as Code with Terraform"
-  img:  "/img/speaker-avatars/armin-deliomini.jpg"
--
-  name: "Peter Schöppl"
-  talk: "EU Datenschutz Grundverordnung"
-  img:  "/img/speaker-avatars/schoeppl_peter_small.jpg"
--
-  name: "Thomas Profelt"
-  talk: "GraphQL Legends"
-  img:  "/img/speaker-avatars/thomas-profelt.jpg"
+talks:
+- title: "Infrastructure as Code with Terraform"
+  speakers:
+    - name: "Armin Deliomini"
+      img: "/img/speaker-avatars/armin-deliomini.jpg"
+- title: "EU Datenschutz Grundverordnung"
+  speakers:
+    - name: "Peter Schöppl"
+      img: "/img/speaker-avatars/schoeppl_peter_small.jpg"
+- title: "GraphQL Legends"
+  speakers:
+    - name: "Thomas Profelt"
+      img: "/img/speaker-avatars/thomas-profelt.jpg"
 ---

--- a/_plauscherl/52.html
+++ b/_plauscherl/52.html
@@ -20,17 +20,17 @@ location:
     lat: 48.3352289652234
     lng: 14.324333373333957
 sponsor: <a href="https://www.xxxlutz.at/">XXXLutz</a>
-speakers:
--
-  name: Armin Mandara
-  talk: "The Roots of Agile Development"
-  img:  "/img/speaker-avatars/armin-mandara.jpg"
--
-  name: "Thomas Fischl"
-  talk: "Warum sollte ich mich als Entwickler mit Biologie beschäftigen?"
-  img:  "/img/speaker-avatars/thomas-fischl.jpg"
--
-  name: "Robert Wille"
-  talk: "Make Design Automation Available for Everyone"
-  img:  "/img/speaker-avatars/robert-wille.jpg"
+talks:
+- title: "The Roots of Agile Development"
+  speakers:
+    - name: "Armin Mandara"
+      img: "/img/speaker-avatars/armin-mandara.jpg"
+- title: "Warum sollte ich mich als Entwickler mit Biologie beschäftigen?"
+  speakers:
+    - name: "Thomas Fischl"
+      img: "/img/speaker-avatars/thomas-fischl.jpg"
+- title: "Make Design Automation Available for Everyone"
+  speakers:
+    - name: "Robert Wille"
+      img: "/img/speaker-avatars/robert-wille.jpg"
 ---

--- a/_plauscherl/53.html
+++ b/_plauscherl/53.html
@@ -22,19 +22,19 @@ location:
     lat: 48.31900698200975
     lng: 14.30473825105721
 sponsor: <a href="https://www.karriere.at/">karriere.at</a>
-speakers:
--
-  name: "Johannes Pichler"
-  talk: "Getting more out of Git"
-  img: /img/speaker-avatars/johannes-pichler.jpg
-  talklink: https://johannespichler.com/slides/getting-more-out-of-git.pdf
--
-  name: "Hannes Brandstätter-Müller"
-  talk: "3D-Druck: Intro für Interessierte"
-  img: /img/speaker-avatars/HannesBrandstaetterMueller_small.jpg
--
-  name: "Paul Emathinger"
-  talk: "Blockchain - More than just digital currencies"
-  img: /img/speaker-avatars/paul_emathinger.jpg
-  talklink: https://docs.google.com/presentation/d/18YXcy6fYdvNnOzj6inHP9RvfGwFEefZR9byUSY3EhVk/export/pdf?id=18YXcy6fYdvNnOzj6inHP9RvfGwFEefZR9byUSY3EhVk
+talks:
+- title: "Getting more out of Git"
+  speakers:
+    - name: "Johannes Pichler"
+      img: "/img/speaker-avatars/johannes-pichler.jpg"
+  talklink: "https://johannespichler.com/slides/getting-more-out-of-git.pdf"
+- title: "3D-Druck: Intro für Interessierte"
+  speakers:
+    - name: "Hannes Brandstätter-Müller"
+      img: "/img/speaker-avatars/HannesBrandstaetterMueller_small.jpg"
+- title: "Blockchain - More than just digital currencies"
+  speakers:
+    - name: "Paul Emathinger"
+      img: "/img/speaker-avatars/paul_emathinger.jpg"
+  talklink: "https://docs.google.com/presentation/d/18YXcy6fYdvNnOzj6inHP9RvfGwFEefZR9byUSY3EhVk/export/pdf?id=18YXcy6fYdvNnOzj6inHP9RvfGwFEefZR9byUSY3EhVk"
 ---

--- a/_plauscherl/54.html
+++ b/_plauscherl/54.html
@@ -22,17 +22,17 @@ location:
     lat: 48.30135543411172
     lng: 14.294128251141789
 sponsor: <a href="https://www.wko.at/">Wirtschaftskammer OÖ</a>
-speakers:
--
-  name: "David Tanzer"
-  talk: "Self Publishing"
-  img: "/img/speaker-avatars/david_tanzer.jpg"
--
-  name: Andreas Gattinger
-  talk: "Arbeitsvertrag, freier Dienstvertrag oder Werkvertrag? – eine Herausforderung besonderer Art"
-  img: /img/speaker-avatars/andreas-gattinger.jpg
--
-  name: André Steingres
-  talk: Senior Entwickler für Anfänger
-  img: https://dtr.fm/wp-content/uploads/2013/09/cd8e1a73298b1e6c8caa9bec4e874583.png
+talks:
+- title: "Self Publishing"
+  speakers:
+    - name: "David Tanzer"
+      img: "/img/speaker-avatars/david_tanzer.jpg"
+- title: "Arbeitsvertrag, freier Dienstvertrag oder Werkvertrag? – eine Herausforderung besonderer Art"
+  speakers:
+    - name: "Andreas Gattinger"
+      img: "/img/speaker-avatars/andreas-gattinger.jpg"
+- title: "Senior Entwickler für Anfänger"
+  speakers:
+    - name: "André Steingres"
+      img: "https://dtr.fm/wp-content/uploads/2013/09/cd8e1a73298b1e6c8caa9bec4e874583.png"
 ---

--- a/_plauscherl/55.html
+++ b/_plauscherl/55.html
@@ -22,17 +22,17 @@ location:
     lat: 48.24086531900188
     lng: 14.234195755222851
 sponsor: <a href="https://www.tractive.com/">Tractive</a>
-speakers:
--
-  name: "Hubert Ströbitzer"
-  talk: "DevOps Questionnaire"
-  img: "/img/speaker-avatars/hubert-stroebitzer.jpg"
--
-  name: "Leo Peneder"
-  talk: "Value First in der Softwareentwicklung"
-  img: "/img/speaker-avatars/leo-peneder.jpg"
--
-  name: "Clemens Kaar"
-  talk: "Data Driven Decisions for Dummies"
-  img: "/img/speaker-avatars/clemens kaar.jpg"
+talks:
+- title: "DevOps Questionnaire"
+  speakers:
+    - name: "Hubert Ströbitzer"
+      img: "/img/speaker-avatars/hubert-stroebitzer.jpg"
+- title: "Value First in der Softwareentwicklung"
+  speakers:
+    - name: "Leo Peneder"
+      img: "/img/speaker-avatars/leo-peneder.jpg"
+- title: "Data Driven Decisions for Dummies"
+  speakers:
+    - name: "Clemens Kaar"
+      img: "/img/speaker-avatars/clemens kaar.jpg"
 ---

--- a/_plauscherl/56.html
+++ b/_plauscherl/56.html
@@ -22,17 +22,17 @@ location:
     lat: 48.255060371510744
     lng: 14.375989832707075
 sponsor: <a href="https://www.celum.com/">Celum</a>
-speakers:
--
-  name: "Donovan Brown"
-  talk: "DevOps for Any Language and Any Platform"
-  img: "https://donovanbrown.com/Custom/Themes/Standard/src/img/logo.png"
--
-  name: "Rainer Pichler"
-  talk: "Exploring the JanusGraph Database using the Gremlin Query Language"
-  img: "/img/speaker-avatars/rainer-pichler.jpg"
--
-  name: "Rainer Stropek"
-  talk: "WebAssembly Revolution am Beispiel von Blazor"
-  img: "https://avatars1.githubusercontent.com/u/2341573?s=460&v=4"
+talks:
+- title: "DevOps for Any Language and Any Platform"
+  speakers:
+    - name: "Donovan Brown"
+      img: "https://donovanbrown.com/Custom/Themes/Standard/src/img/logo.png"
+- title: "Exploring the JanusGraph Database using the Gremlin Query Language"
+  speakers:
+    - name: "Rainer Pichler"
+      img: "/img/speaker-avatars/rainer-pichler.jpg"
+- title: "WebAssembly Revolution am Beispiel von Blazor"
+  speakers:
+    - name: "Rainer Stropek"
+      img: "https://avatars1.githubusercontent.com/u/2341573?s=460&v=4"
 ---

--- a/_plauscherl/57.html
+++ b/_plauscherl/57.html
@@ -22,18 +22,18 @@ location:
     lat: 48.29088256307852
     lng: 14.288329320379118
 sponsor: <a href="https://www.cswp.at/">Consolution</a>
-speakers:
--
-  name: "Stefan Schaffelhofer"
-  talk: "Computer-Gehirnschnittstellen: Technologie und Ethik"
-  img: "/img/speaker-avatars/stefan-schaffelhofer.jpg"
--
-  name: "Thomas R. Koll"
-  talk: "DSL in Ruby - So schnell entsteht eine domainspezifische Sprache"
-  img: "//tomk32.github.io/assets/tomk32.jpg"
+talks:
+- title: "Computer-Gehirnschnittstellen: Technologie und Ethik"
+  speakers:
+    - name: "Stefan Schaffelhofer"
+      img: "/img/speaker-avatars/stefan-schaffelhofer.jpg"
+- title: "DSL in Ruby - So schnell entsteht eine domainspezifische Sprache"
+  speakers:
+    - name: "Thomas R. Koll"
+      img: "//tomk32.github.io/assets/tomk32.jpg"
   talklink: "https://tomk32.github.io/presentations/de/ruby-dsl"
--
-  name: "David Tanzer"
-  talk: "The Mikado Method for Legacy Code"
-  img: "/img/speaker-avatars/david_tanzer.jpg"
+- title: "The Mikado Method for Legacy Code"
+  speakers:
+    - name: "David Tanzer"
+      img: "/img/speaker-avatars/david_tanzer.jpg"
 ---

--- a/_plauscherl/58.html
+++ b/_plauscherl/58.html
@@ -20,17 +20,17 @@ location:
     lat: 48.3125250952205
     lng: 14.298081718795546
 sponsor: <a href="https://www.netural.com/">Netural</a>
-speakers:
--
-  name: "Klaus Fischer"
-  talk: "CSS Grids"
-  img: "/img/speaker-avatars/klaus_fischer.jpg"
--
-  name: "Klaus Lehner"
-  talk: "Software architecture as code"
-  img: "https://avatars0.githubusercontent.com/u/172195?v=3&s=200"
--
-  name: "Stefan Baumgartner"
-  talk: "TypeScript Oddities"
-  img: "https://pbs.twimg.com/profile_images/572642811029426177/GxgFcPtm_400x400.jpeg"
+talks:
+- title: "CSS Grids"
+  speakers:
+    - name: "Klaus Fischer"
+      img: "/img/speaker-avatars/klaus_fischer.jpg"
+- title: "Software architecture as code"
+  speakers:
+    - name: "Klaus Lehner"
+      img: "https://avatars0.githubusercontent.com/u/172195?v=3&s=200"
+- title: "TypeScript Oddities"
+  speakers:
+    - name: "Stefan Baumgartner"
+      img: "https://pbs.twimg.com/profile_images/572642811029426177/GxgFcPtm_400x400.jpeg"
 ---

--- a/_plauscherl/59.html
+++ b/_plauscherl/59.html
@@ -20,16 +20,16 @@ location:
     lat: 48.31182930946286
     lng: 14.299438296133726
 sponsor: <a href="https://smarter-ecommerce.com">Smarter Ecommerce (SMEC)</a>
-speakers:
--
-  name: Peter Lanser
-  talk: "1,5yrs of GraphQL experience - the Good, the Bad and the Ugly"
--
-  name: "Markus Zöchling"
-  talk: "Highway 2 Hell - Dont's in Softwareentwicklungsorganisationen"
-  img: /img/speaker-avatars/markus-zoechling.jpg
--
-  name: Robert Schmelzer
-  talk: "Don't break the API"
-  img: //x1.xingassets.com/image/7_3_0_b57234808_3452160_1/robert-schmelzer-foto.256x256.jpg
+talks:
+- title: "1,5yrs of GraphQL experience - the Good, the Bad and the Ugly"
+  speakers:
+    - name: "Peter Lanser"
+- title: "Highway 2 Hell - Dont's in Softwareentwicklungsorganisationen"
+  speakers:
+    - name: "Markus Zöchling"
+      img: "/img/speaker-avatars/markus-zoechling.jpg"
+- title: "Don't break the API"
+  speakers:
+    - name: "Robert Schmelzer"
+      img: "//x1.xingassets.com/image/7_3_0_b57234808_3452160_1/robert-schmelzer-foto.256x256.jpg"
 ---

--- a/_plauscherl/60.html
+++ b/_plauscherl/60.html
@@ -20,16 +20,17 @@ location:
     lat: 48.31727531132974
     lng: 14.28834788234948
 sponsor: <a href="https://www.keba.com">KEBA</a>
-speakers:
--
-  name: Hermann Steffan
-  talk: "The ROS Framework"
--
-  name: Andreas Sackl & Georg Regal
-  talk: "User Experience Messung und Technology Acceptance"
--
-  name: Arno Hütter
-  talk: "Chess Engine Programming"
-  talklink: https://www.slideshare.net/ArnoHuetter/chess-engine-programming
-  img: //avatars.githubusercontent.com/u/13778307
+talks:
+- title: "The ROS Framework"
+  speakers:
+    - name: "Hermann Steffan"
+- title: "User Experience Messung und Technology Acceptance"
+  speakers:
+    - name: "Andreas Sackl"
+    - name: "Georg Regal"
+- title: "Chess Engine Programming"
+  speakers:
+    - name: "Arno Hütter"
+      img: "//avatars.githubusercontent.com/u/13778307"
+  talklink: "https://www.slideshare.net/ArnoHuetter/chess-engine-programming"
 ---

--- a/_plauscherl/61.html
+++ b/_plauscherl/61.html
@@ -20,15 +20,15 @@ location:
     lat: 48.329348
     lng: 14.3202109
 sponsor: <a href="https://jobs.dynatrace.at/">Dynatrace</a>
-speakers:
--
-  name: Martin Gutenbrunner
-  talk: "Ich bau mir meine Haussteuerung selber! ... 10 Jahre später"
-  img: https://www.xing.com/image/6_e_7_b38434099_16347468_2/martin-gutenbrunner-foto.1024x1024.jpg
--
-  name: Karl Artmann
-  talk: Mentimeter
--
-  name: Johannes Waslmeier
-  talk: A11Y Tests
+talks:
+- title: "Ich bau mir meine Haussteuerung selber! ... 10 Jahre später"
+  speakers:
+    - name: "Martin Gutenbrunner"
+      img: "https://www.xing.com/image/6_e_7_b38434099_16347468_2/martin-gutenbrunner-foto.1024x1024.jpg"
+- title: "Mentimeter"
+  speakers:
+    - name: "Karl Artmann"
+- title: "A11Y Tests"
+  speakers:
+    - name: "Johannes Waslmeier"
 ---

--- a/_plauscherl/62.html
+++ b/_plauscherl/62.html
@@ -20,17 +20,17 @@ location:
     lat: 48.264409960267066
     lng: 14.34046037062007
 sponsor: <a href="https://www.ds-automotion.com/">DS Automotion</a>
-speakers:
--
-  name: Patrick Schöppl
-  talk: DSL mit ANTLR4
-  img: /img/speaker-avatars/patrick-schoeppl.jpg
--
-  name: Thomas Würthinger
-  talk: "GraalVM: High performance polyglot runtime"
-  img: //avatars1.githubusercontent.com/u/5550412?s=460&v=4
--
-  name: Karl Artmann
-  talk: Template engines considered harmful
-  img: /img/speaker-avatars/karl-artmann.jpg
+talks:
+- title: "DSL mit ANTLR4"
+  speakers:
+    - name: "Patrick Schöppl"
+      img: "/img/speaker-avatars/patrick-schoeppl.jpg"
+- title: "GraalVM: High performance polyglot runtime"
+  speakers:
+    - name: "Thomas Würthinger"
+      img: "//avatars1.githubusercontent.com/u/5550412?s=460&v=4"
+- title: "Template engines considered harmful"
+  speakers:
+    - name: "Karl Artmann"
+      img: "/img/speaker-avatars/karl-artmann.jpg"
 ---

--- a/_plauscherl/63.html
+++ b/_plauscherl/63.html
@@ -20,17 +20,17 @@ location:
     lat: 48.311839
     lng: 14.297415
 sponsor: <a href="https://www.catalysts.cc/">Catalysts</a>
-speakers:
--
-  name: Paul Lanzerstorfer
-  talk: Agile Softwareentwicklung in der Linzer IT-Community
-  img: "//xing.com/img/users/9/9/1/016bbe0f8.14932083,3.256x256.jpg"
--
-  name: Karina Streng
-  talk: "Führen mit einem Techniker-Herz"
-  img:  "/img/speaker-avatars/karina-streng.jpg"
--
-  name: Christian Weiß
-  talk: Distributed Tracing
-  img: "//xing.com/img/users/9/c/0/b4c2399f2.21276279,2.1024x1024.jpg"
+talks:
+- title: "Agile Softwareentwicklung in der Linzer IT-Community"
+  speakers:
+    - name: "Paul Lanzerstorfer"
+      img: "//xing.com/img/users/9/9/1/016bbe0f8.14932083,3.256x256.jpg"
+- title: "Führen mit einem Techniker-Herz"
+  speakers:
+    - name: "Karina Streng"
+      img: "/img/speaker-avatars/karina-streng.jpg"
+- title: "Distributed Tracing"
+  speakers:
+    - name: "Christian Weiß"
+      img: "//xing.com/img/users/9/c/0/b4c2399f2.21276279,2.1024x1024.jpg"
 ---

--- a/_plauscherl/64.html
+++ b/_plauscherl/64.html
@@ -21,17 +21,17 @@ location:
     lat: 48.316771
     lng: 14.304529
 sponsor: <a href="https://www.mic-cust.com">www.mic-cust.com</a>
-speakers:
--
-  name: Norbert Kehrer
-  talk: Die Zuse Z22 - Der erste Computer in Oberösterreich
-  img: "/img/speaker-avatars/norbert-kehrer.jpg"
--
-  name: Markus Zuser
-  talk: "Bake the monolith, break the monolith"
-  img:  "/img/speaker-avatars/markus-zuser.jpg"
--
-  name: Dejan Jukic
-  talk: Istio Service Mesh
-  img: "/img/speaker-avatars/dejan-jukic.jpg"
+talks:
+- title: "Die Zuse Z22 - Der erste Computer in Oberösterreich"
+  speakers:
+    - name: "Norbert Kehrer"
+      img: "/img/speaker-avatars/norbert-kehrer.jpg"
+- title: "Bake the monolith, break the monolith"
+  speakers:
+    - name: "Markus Zuser"
+      img: "/img/speaker-avatars/markus-zuser.jpg"
+- title: "Istio Service Mesh"
+  speakers:
+    - name: "Dejan Jukic"
+      img: "/img/speaker-avatars/dejan-jukic.jpg"
 ---

--- a/_plauscherl/65.html
+++ b/_plauscherl/65.html
@@ -21,17 +21,17 @@ location:
     lat: 48.3125000271247
     lng: 14.2994160663288
 sponsor: <a href="https://grandgarage.eu/">Grand Garage</a>
-speakers:
--
-  name: "Paul Latzelsberger & Karina Streng"
-  talk: CODERS.BAY - Behind the Scenes
-  img: "https://media.licdn.com/dms/image/C5103AQEEW9j1OlDpbA/profile-displayphoto-shrink_800_800/0?e=1557360000&v=beta&t=BQIj24gEeuGESHOXnvEvPanQBwGEKjkwaRWerdQqbFw"
--
-  name: Christian Schwendtner
-  talk: "Azure Event Grid in Action"
-  img:  "/img/speaker-avatars/christian-schwendtner.png"
--
-  name: Martin Weber
-  talk: "From Raw Data to Classification API"
-  img: //avatars0.githubusercontent.com/u/7472943?v=3&s=200
+talks:
+- title: "CODERS.BAY - Behind the Scenes"
+  speakers:
+    - name: "Paul Latzelsberger"
+    - name: "Karina Streng"
+- title: "Azure Event Grid in Action"
+  speakers:
+    - name: "Christian Schwendtner"
+      img: "/img/speaker-avatars/christian-schwendtner.png"
+- title: "From Raw Data to Classification API"
+  speakers:
+    - name: "Martin Weber"
+      img: "//avatars0.githubusercontent.com/u/7472943?v=3&s=200"
 ---

--- a/_plauscherl/66.html
+++ b/_plauscherl/66.html
@@ -22,17 +22,17 @@ location:
     lat: 48.29088256307852
     lng: 14.288329320379118
 sponsor: <a href="https://www.fronius.com/">Fronius</a>
-speakers:
--
-  name: "Kathrin Kefer"
-  talk: "Fronius Energiemanagement von Heute und Morgen"
-  img: "/img/speaker-avatars/kathrin-kefer.jpg"
--
-  name: "Emmanuel Helm"
-  talk: "Process Mining (EN)"
-  img: "/img/speaker-avatars/emmanuel-helm.jpg"
--
-  name: "Christoph Strobl"
-  talk: "Einfach Reaktiv - Ich bau mir dann mal einen non blocking Elasticsearch Client (EN)"
-  img: "//pbs.twimg.com/profile_images/976017011364040704/gnb_jSl9_400x400.jpg"
+talks:
+- title: "Fronius Energiemanagement von Heute und Morgen"
+  speakers:
+    - name: "Kathrin Kefer"
+      img: "/img/speaker-avatars/kathrin-kefer.jpg"
+- title: "Process Mining (EN)"
+  speakers:
+    - name: "Emmanuel Helm"
+      img: "/img/speaker-avatars/emmanuel-helm.jpg"
+- title: "Einfach Reaktiv - Ich bau mir dann mal einen non blocking Elasticsearch Client (EN)"
+  speakers:
+    - name: "Christoph Strobl"
+      img: "//pbs.twimg.com/profile_images/976017011364040704/gnb_jSl9_400x400.jpg"
 ---

--- a/_plauscherl/67.html
+++ b/_plauscherl/67.html
@@ -20,17 +20,17 @@ location:
     lat: 48.317307
     lng: 14.287531
 sponsor: <a href="https://dataformers.at/">dataformers GmbH</a>
-speakers:
--
-  name: "Helmut Gaffl"
-  talk: "Copernicus - Europe's eyes on Earth"
-  img: /img/speaker-avatars/helmut-gaffl.jpg
--
-  name: "Jürgen Brandstetter"
-  talk: "Lean Canvas - a simple and effective way to validate your (startup) idea (EN)"
-  img: "//www.amy.app/img/profile_circle/jurgen_circle.png"
--
-  name: "Phil Reither"
-  talk: "A Geeks Guide to Investing"
-  img: //avatars2.githubusercontent.com/u/2776512?v=3&s=200
+talks:
+- title: "Copernicus - Europe's eyes on Earth"
+  speakers:
+    - name: "Helmut Gaffl"
+      img: "/img/speaker-avatars/helmut-gaffl.jpg"
+- title: "Lean Canvas - a simple and effective way to validate your (startup) idea (EN)"
+  speakers:
+    - name: "Jürgen Brandstetter"
+      img: "//www.amy.app/img/profile_circle/jurgen_circle.png"
+- title: "A Geeks Guide to Investing"
+  speakers:
+    - name: "Phil Reither"
+      img: "//avatars2.githubusercontent.com/u/2776512?v=3&s=200"
 ---

--- a/_plauscherl/68.html
+++ b/_plauscherl/68.html
@@ -20,16 +20,16 @@ location:
     lat: 48.29144354065417
     lng: 14.305095616992443
 sponsor: <a href="https://www.r-software.at">Raiffeisen Software</a>
-speakers:
--
-  name: "Thomas Kriechbaum"
-  talk: "Meine Bank - Die digitale Transformation"
--
-  name: "Thomas Einwaller & Markus Klein"
-  talk: "Livestream Technik"
-  img: /img/speaker-avatars/tomarkus-kleinwaller.jpg
--
-  name: "Jürgen Etzlstorfer"
-  talk: "Cloud-Native Continous Delivery & Operations with keptn.sh"
-  img: /img/speaker-avatars/juergen-etzlstorfer.jpg
+talks:
+- title: "Meine Bank - Die digitale Transformation"
+  speakers:
+    - name: "Thomas Kriechbaum"
+- title: "Livestream Technik"
+  speakers:
+    - name: "Thomas Einwaller & Markus Klein"
+      img: "/img/speaker-avatars/tomarkus-kleinwaller.jpg"
+- title: "Cloud-Native Continous Delivery & Operations with keptn.sh"
+  speakers:
+    - name: "Jürgen Etzlstorfer"
+      img: "/img/speaker-avatars/juergen-etzlstorfer.jpg"
 ---

--- a/_plauscherl/69.html
+++ b/_plauscherl/69.html
@@ -20,17 +20,17 @@ location:
     lat: 48.31000272894287
     lng: 14.294939692711651
 sponsor: <a href="https://www.fabasoft.com">Fabasoft</a>
-speakers:
--
-  name: "Rainer Pichler"
-  talk: "Reactive Microservices: Node.js vs. Java"
-  img: /img/speaker-avatars/rainer-pichler.jpg
--
-  name: "Boyang Xia"
-  talk: "How to ~Not~ DevOps on OpenShift"
-  img: /img/speaker-avatars/boyang-xia.jpg
--
-  name: "Gerald Bauer"
-  talk: "Using Git (and GitHub) for (Publishing) Data - factbook.json & Co"
-  img: https://avatars3.githubusercontent.com/u/53281
+talks:
+- title: "Reactive Microservices: Node.js vs. Java"
+  speakers:
+    - name: "Rainer Pichler"
+      img: "/img/speaker-avatars/rainer-pichler.jpg"
+- title: "How to ~Not~ DevOps on OpenShift"
+  speakers:
+    - name: "Boyang Xia"
+      img: "/img/speaker-avatars/boyang-xia.jpg"
+- title: "Using Git (and GitHub) for (Publishing) Data - factbook.json & Co"
+  speakers:
+    - name: "Gerald Bauer"
+      img: "https://avatars3.githubusercontent.com/u/53281"
 ---

--- a/_plauscherl/70.html
+++ b/_plauscherl/70.html
@@ -20,14 +20,14 @@ location:
     lat: 48.311447909269894
     lng: 14.298800100771492
 sponsor: <a href="https://startup300.at/">startup300</a>
-speakers:
--
-  name: "Manuel Baumgartner"
-  talk: "Automatisierter Datenschutz"
--
-  name: "Rainer Stropek"
-  talk: "Go"
--
-  name: "Christian Füreder"
-  talk: "Juristische Praxisprobleme im Software-Projektmanagement"
+talks:
+- title: "Automatisierter Datenschutz"
+  speakers:
+    - name: "Manuel Baumgartner"
+- title: "Go"
+  speakers:
+    - name: "Rainer Stropek"
+- title: "Juristische Praxisprobleme im Software-Projektmanagement"
+  speakers:
+    - name: "Christian Füreder"
 ---

--- a/_plauscherl/71.html
+++ b/_plauscherl/71.html
@@ -20,15 +20,15 @@ location:
     lat: 48.281302634269224
     lng: 14.307272867570585
 sponsor: <a href="https://www.siemens.at/">siemens</a>
-speakers:
--
-  name: "Marc Eissele"
-  talk: "Multi Agent SCADA Systeme"
--
-  name: "Michael Lanzinger"
-  talk: "Urheberrecht meets Datenschutz: Bilder von Personen und die Mythen darum"
-  img: /img/speaker-avatars/michael_lanzinger.jpg
--
-  name: "Christoph Strobl"
-  talk: "A Sneak Peek on What's new in Spring Data Moore"
+talks:
+- title: "Multi Agent SCADA Systeme"
+  speakers:
+    - name: "Marc Eissele"
+- title: "Urheberrecht meets Datenschutz: Bilder von Personen und die Mythen darum"
+  speakers:
+    - name: "Michael Lanzinger"
+      img: "/img/speaker-avatars/michael_lanzinger.jpg"
+- title: "A Sneak Peek on What's new in Spring Data Moore"
+  speakers:
+    - name: "Christoph Strobl"
 ---

--- a/_plauscherl/72.html
+++ b/_plauscherl/72.html
@@ -20,16 +20,16 @@ location:
     lat: 48.3352289652234
     lng: 14.324333373333957
 sponsor: <a href="https://risc-software.at/">RISC Software</a>
-speakers:
--
-  name: Franz Eder
-  talk: Lehre als Applikationsentwickler
-  img:  "/img/speaker-avatars/franz-eder.jpg"
--
-  name: Tobias Höller
-  talk: Austrian students vs Russian Hackers
--
-  name: Michael Hava
-  talk: "Not your grandfather‘s C++"
-  img: "/img/speaker-avatars/michael-hava.jpg"
+talks:
+- title: "Lehre als Applikationsentwickler"
+  speakers:
+    - name: "Franz Eder"
+      img: "/img/speaker-avatars/franz-eder.jpg"
+- title: "Austrian students vs Russian Hackers"
+  speakers:
+    - name: "Tobias Höller"
+- title: "Not your grandfather‘s C++"
+  speakers:
+    - name: "Michael Hava"
+      img: "/img/speaker-avatars/michael-hava.jpg"
 ---

--- a/_plauscherl/73.html
+++ b/_plauscherl/73.html
@@ -22,13 +22,13 @@ location:
     lat: 48.25518018268946
     lng: 14.376038089611576
 sponsor: <a href="https://www.celum.com/">Celum</a>
-speakers:
--
-  name: "Lukasz Gorski"
-  talk: "BDD – The pickle in your JAR"
-  img: "/img/speaker-avatars/lukasz-gorski.jpg"
--
-  name: "Rainer Stropek"
-  talk: "Exploring Memory Ownership in Rust and C#"
-  img: "https://avatars1.githubusercontent.com/u/2341573?s=460&v=4"
+talks:
+- title: "BDD – The pickle in your JAR"
+  speakers:
+    - name: "Lukasz Gorski"
+      img: "/img/speaker-avatars/lukasz-gorski.jpg"
+- title: "Exploring Memory Ownership in Rust and C#"
+  speakers:
+    - name: "Rainer Stropek"
+      img: "https://avatars1.githubusercontent.com/u/2341573?s=460&v=4"
 ---

--- a/_plauscherl/74.html
+++ b/_plauscherl/74.html
@@ -22,17 +22,17 @@ location:
     lat: 48.31900698200975
     lng: 14.30473825105721
 sponsor: <a href="https://www.karriere.at/">karriere.at</a>
-speakers:
--
-  name: "Daniel Surenjan"
-  talk: "Data Actually: A Hero's journey"
-  img: "/img/speaker-avatars/daniel_surenjan.jpg"
--
-  name: "Christoph Kofler"
-  talk: "Hack your habits"
-  img: "/img/speaker-avatars/chris-kofler.jpg"
--
-  name: "Hannes Elmer"
-  talk: "CTO-as-a-service, Erfahrungen aus dem Alltag"
-  img: "/img/speaker-avatars/hannes-elmer.jpg"
+talks:
+- title: "Data Actually: A Hero's journey"
+  speakers:
+    - name: "Daniel Surenjan"
+      img: "/img/speaker-avatars/daniel_surenjan.jpg"
+- title: "Hack your habits"
+  speakers:
+    - name: "Christoph Kofler"
+      img: "/img/speaker-avatars/chris-kofler.jpg"
+- title: "CTO-as-a-service, Erfahrungen aus dem Alltag"
+  speakers:
+    - name: "Hannes Elmer"
+      img: "/img/speaker-avatars/hannes-elmer.jpg"
 ---

--- a/_plauscherl/75.html
+++ b/_plauscherl/75.html
@@ -17,16 +17,16 @@ location:
   city: "Linz"
   zip: "4020"
 sponsor: <a href="https://www.netural.com/">Netural</a>
-speakers:
--
-   name: "Klaus Fischer"
-   talk: "Frontendg'schichten und Backendsachen - Knistern im agilen Entwicklungsalltag"
-   img: "/img/speaker-avatars/klaus_fischer.jpg"
--
-   name: "Stefan Schindler"
-   talk: "Grafana Security Proxy in Rust"
-   img: "/img/speaker-avatars/stefan-schindler.jpg"
--
-   name: "Alexander Sattleder"
-   talk: "Kids & Devs - Erlebnispaedagogik in Agile Trainings"
+talks:
+- title: "Frontendg'schichten und Backendsachen - Knistern im agilen Entwicklungsalltag"
+  speakers:
+    - name: "Klaus Fischer"
+      img: "/img/speaker-avatars/klaus_fischer.jpg"
+- title: "Grafana Security Proxy in Rust"
+  speakers:
+    - name: "Stefan Schindler"
+      img: "/img/speaker-avatars/stefan-schindler.jpg"
+- title: "Kids & Devs - Erlebnispaedagogik in Agile Trainings"
+  speakers:
+    - name: "Alexander Sattleder"
 ---

--- a/_plauscherl/76.html
+++ b/_plauscherl/76.html
@@ -23,25 +23,25 @@ location:
     lat: 48.24086531900188
     lng: 14.234195755222851
 sponsor: <a href="https://www.tractive.com/">Tractive</a>
-speakers:
--
-   name: "Dominik Hurnaus"
-   talk: "Challenges & Lessons Learned in IoT"
-   img: "//avatars0.githubusercontent.com/u/106848?v=3&s=200"
-   language: "en"
--
-   name: "Stefan Schöberl"
-   talk: "WebAssembly: Bare Metal"
-   img: "//schoeberl.dev/images/me.jpg"
-   language: "en"
--
-   name: "Michael Hitzker"
-   talk: "Flutter + Apple Watch = No Problem"
-   img: "//avatars.githubusercontent.com/u/33837887?v=4&s=320"
-   language: "en"
--
-   name: "Stefan Baumgartner"
-   talk: "Rust for Curious Developers"
-   img: "//avatars3.githubusercontent.com/u/1374451?v=3&s=200"
-   language: "en"
+talks:
+- title: "Challenges & Lessons Learned in IoT"
+  speakers:
+    - name: "Dominik Hurnaus"
+      img: "//avatars0.githubusercontent.com/u/106848?v=3&s=200"
+  language: "en"
+- title: "WebAssembly: Bare Metal"
+  speakers:
+    - name: "Stefan Schöberl"
+      img: "//schoeberl.dev/images/me.jpg"
+  language: "en"
+- title: "Flutter + Apple Watch = No Problem"
+  speakers:
+    - name: "Michael Hitzker"
+      img: "//avatars.githubusercontent.com/u/33837887?v=4&s=320"
+  language: "en"
+- title: "Rust for Curious Developers"
+  speakers:
+    - name: "Stefan Baumgartner"
+      img: "//avatars3.githubusercontent.com/u/1374451?v=3&s=200"
+  language: "en"
 ---

--- a/_plauscherl/77.html
+++ b/_plauscherl/77.html
@@ -23,25 +23,25 @@ location:
     lat: 48.31523804488036
     lng: 14.305155772716896
 sponsor: <a href="https://dynatrace.com">Dynatrace</a>
-speakers:
--
-   name: Martin Gutenbrunner
-   talk: "The 8 Bit Theory: Obsolete but not Useless"
-   img: "https://www.xing.com/image/6_e_7_b38434099_16347468_2/martin-gutenbrunner-foto.1024x1024.jpg"
-   language: en
--
-   name: "Gerald Bauer"
-   talk: "Inside the Billion Dollar Crypto Punk Pixel Heads"
-   img: https://avatars3.githubusercontent.com/u/53281
-   language: en
--
-   name: "Benjamin Hollentin"
-   talk: "System Monitoring mit CheckMK"
-   img: "/img/speaker-avatars/benjamin-hollentin.jpg"
-   language: en
--
-   name: Simon Lasselsberger 
-   talk: "Communicate efficiently with Software Architecture Diagrams"
-   img: "//www.lasssim.com/wp-content/uploads/2022/08/avatar_2021.jpg"
-   language: en
+talks:
+- title: "The 8 Bit Theory: Obsolete but not Useless"
+  speakers:
+    - name: "Martin Gutenbrunner"
+      img: "https://www.xing.com/image/6_e_7_b38434099_16347468_2/martin-gutenbrunner-foto.1024x1024.jpg"
+  language: "en"
+- title: "Inside the Billion Dollar Crypto Punk Pixel Heads"
+  speakers:
+    - name: "Gerald Bauer"
+      img: "https://avatars3.githubusercontent.com/u/53281"
+  language: "en"
+- title: "System Monitoring mit CheckMK"
+  speakers:
+    - name: "Benjamin Hollentin"
+      img: "/img/speaker-avatars/benjamin-hollentin.jpg"
+  language: "en"
+- title: "Communicate efficiently with Software Architecture Diagrams"
+  speakers:
+    - name: "Simon Lasselsberger"
+      img: "//www.lasssim.com/wp-content/uploads/2022/08/avatar_2021.jpg"
+  language: "en"
 ---

--- a/_plauscherl/78.html
+++ b/_plauscherl/78.html
@@ -23,25 +23,25 @@ location:
     lat: 48.303619026937284
     lng: 14.299148350489265
 sponsor: <a href="https://cloudflight.io">Cloudflight</a>
-speakers:
--
-   name: Stefan Starke
-   talk: "Azure yourself, there is a lot to learn"
-   img: "/img/speaker-avatars/stefan-starke.jpg"
-   language: en
--
-   name: Christian Olear
-   talk: "Building the Crawling System I wanted to have"
-   img: "/img/speaker-avatars/christian-olear.jpg"
-   language: en
--
-   name: Martin Forstner
-   talk: "Accessibility - Essential for some. Useful for all"
-   img: "/img/speaker-avatars/forstner_martin.jpg"
-   language: en
--
-   name: David Tanzer
-   talk: "Contract testing with Pact"
-   img: "/img/speaker-avatars/david_tanzer.jpg"
-   language: en
+talks:
+- title: "Azure yourself, there is a lot to learn"
+  speakers:
+    - name: "Stefan Starke"
+      img: "/img/speaker-avatars/stefan-starke.jpg"
+  language: "en"
+- title: "Building the Crawling System I wanted to have"
+  speakers:
+    - name: "Christian Olear"
+      img: "/img/speaker-avatars/christian-olear.jpg"
+  language: "en"
+- title: "Accessibility - Essential for some. Useful for all"
+  speakers:
+    - name: "Martin Forstner"
+      img: "/img/speaker-avatars/forstner_martin.jpg"
+  language: "en"
+- title: "Contract testing with Pact"
+  speakers:
+    - name: "David Tanzer"
+      img: "/img/speaker-avatars/david_tanzer.jpg"
+  language: "en"
 ---

--- a/_plauscherl/79.html
+++ b/_plauscherl/79.html
@@ -23,19 +23,19 @@ location:
     lat: 48.31267908385208
     lng: 14.298413180167765
 sponsor: <a href="https://ubitec.at">Ubitec</a>
-speakers:
--
-   name: "Dominik Aumayr"
-   talk: "How to not lose your billions"
-   img: "/img/speaker-avatars/ubitec_da.jpg"
-   language: en
--
-   name: "Matthias Heiden"
-   talk: "From zero to production with Rust"
-   language: en
--
-   name: "Clare Kato"
-   talk: "Navigating the challenges of the UX-DEV collab"
-   img: "/img/speaker-avatars/clare-kato.png"
-   language: en
+talks:
+- title: "How to not lose your billions"
+  speakers:
+    - name: "Dominik Aumayr"
+      img: "/img/speaker-avatars/ubitec_da.jpg"
+  language: "en"
+- title: "From zero to production with Rust"
+  speakers:
+    - name: "Matthias Heiden"
+  language: "en"
+- title: "Navigating the challenges of the UX-DEV collab"
+  speakers:
+    - name: "Clare Kato"
+      img: "/img/speaker-avatars/clare-kato.png"
+  language: "en"
 ---

--- a/_plauscherl/80.html
+++ b/_plauscherl/80.html
@@ -22,19 +22,19 @@ location:
     lat: 48.29088256307852
     lng: 14.288329320379118
 sponsor: <a href="https://www.fronius.com/">Fronius</a>
-speakers:
--
-  name: "Paul Rohorzka, Raffael Rehberger"
-  talk: "How To Tame the Complexity of Distributed Systems with Actors"
-  img:  /img/speaker-avatars/paul-rohorzka-raffael-rehberger.png
-  language: en
--
-  name: "Gerald Bauer"
-  talk: "Ordinal Inscriptions - Turn the Blockchain Into A Database For Digitial Artefacts"
-  img:  https://avatars3.githubusercontent.com/u/53281
-  language: en
--
-  name: "Hannes Preishuber"
-  talk: "Machine Learning von 0 auf 100"
-  img: "/img/speaker-avatars/hannespreishuber.jpg"
+talks:
+- title: "How To Tame the Complexity of Distributed Systems with Actors"
+  speakers:
+    - name: "Paul Rohorzka, Raffael Rehberger"
+      img: "/img/speaker-avatars/paul-rohorzka-raffael-rehberger.png"
+  language: "en"
+- title: "Ordinal Inscriptions - Turn the Blockchain Into A Database For Digitial Artefacts"
+  speakers:
+    - name: "Gerald Bauer"
+      img: "https://avatars3.githubusercontent.com/u/53281"
+  language: "en"
+- title: "Machine Learning von 0 auf 100"
+  speakers:
+    - name: "Hannes Preishuber"
+      img: "/img/speaker-avatars/hannespreishuber.jpg"
 ---

--- a/_plauscherl/81.html
+++ b/_plauscherl/81.html
@@ -20,17 +20,17 @@ location:
     lat: 48.264409960267066
     lng: 14.34046037062007
 sponsor: <a href="https://www.ds-automotion.com/">DS Automotion</a>
-speakers:
--
-  name: Lukas Schwarz und Markus Bio-Alexander
-  talk: Creating a new base for Web and Embedded development in a fast changing environment
-  img: https://i.ibb.co/s5mV7ZZ/technologieplauscherl.png
-  language: en
--
-  name: Sebastian Steininger und Bernhard Wurm
-  talk: UDP Holepunching - P2P Verbindungen in Zeiten von Videokonferenzen
-  img: https://www.wavenet8.com/_app/immutable/assets/team-d8f0b9f0.png
--
-  name: Philipp Moser
-  talk: Blood flow modeling with physics-informed neural networks
+talks:
+- title: "Creating a new base for Web and Embedded development in a fast changing environment"
+  speakers:
+    - name: "Lukas Schwarz"
+    - name: "Markus Bio-Alexander"
+  language: "en"
+- title: "UDP Holepunching - P2P Verbindungen in Zeiten von Videokonferenzen"
+  speakers:
+    - name: "Sebastian Steininger und Bernhard Wurm"
+      img: "https://www.wavenet8.com/_app/immutable/assets/team-d8f0b9f0.png"
+- title: "Blood flow modeling with physics-informed neural networks"
+  speakers:
+    - name: "Philipp Moser"
 ---

--- a/_plauscherl/82.html
+++ b/_plauscherl/82.html
@@ -20,16 +20,16 @@ location:
     lat: 48.31727531132974
     lng: 14.28834788234948
 sponsor: <a href="https://www.keba.com">KEBA</a>
-speakers:
--
-  name: "Martin Baresch"
-  talk: "Kebob (AI Assistant): Wie denkt und handelt Kebob, Einblick in die Architektur von Kebob"
--
-  name: "Stefan Haas"
-  talk: "Scaling Angular Applications with Nx"
--
-  name: "Michael Aufreiter"
-  talk: "A SvelteKit template for building CMS-free editable websites"
-  img: "https://editable.website/assets/images/4k603cwC1ZtEjcHSC3w3I.webp"
+talks:
+- title: "Kebob (AI Assistant): Wie denkt und handelt Kebob, Einblick in die Architektur von Kebob"
+  speakers:
+    - name: "Martin Baresch"
+- title: "Scaling Angular Applications with Nx"
+  speakers:
+    - name: "Stefan Haas"
+- title: "A SvelteKit template for building CMS-free editable websites"
+  speakers:
+    - name: "Michael Aufreiter"
+      img: "https://editable.website/assets/images/4k603cwC1ZtEjcHSC3w3I.webp"
   talklink: "https://editable.website"
 ---

--- a/_plauscherl/83.html
+++ b/_plauscherl/83.html
@@ -20,14 +20,14 @@ location:
     lat: 48.30188342124369
     lng: 14.311150193535209
 sponsor: <a href="https://www.nts.eu">NTS</a>
-speakers:
--
-  name: "Max Eizenberger"
-  talk: "Customer Onboarding @Scale"
--
-  name: "Matthias Holzinger"
-  talk: "boudicca.events OSS Entwicklung"
--
-  name: "Dominik Falkner"
-  talk: "Integrating Machine Learning in Supply Chain Management"
+talks:
+- title: "Customer Onboarding @Scale"
+  speakers:
+    - name: "Max Eizenberger"
+- title: "boudicca.events OSS Entwicklung"
+  speakers:
+    - name: "Matthias Holzinger"
+- title: "Integrating Machine Learning in Supply Chain Management"
+  speakers:
+    - name: "Dominik Falkner"
 ---

--- a/_plauscherl/84.html
+++ b/_plauscherl/84.html
@@ -20,14 +20,17 @@ location:
         lat: 48.303619026937284
         lng: 14.299148350489265
 sponsor: <a href="https://www.cloudflight.io/">Cloudflight</a>
-speakers:
+talks:
+- title: "Redefining Confluence search using AI"
+  speakers:
     - name: "Marcel Brunnbauer"
-      talk: "Redefining Confluence search using AI"
       img: "/img/speaker-avatars/marcel-brunnbauer.jpg"
-    - name: "Benjamin Hollentin" 
-      talk: "Mathematik neuronaler Netze - Der einfache Teil" 
+- title: "Mathematik neuronaler Netze - Der einfache Teil"
+  speakers:
+    - name: "Benjamin Hollentin"
       img: "/img/speaker-avatars/benjamin-hollentin.jpg"
-    - name: "Eckart Holzinger" 
-      talk: "KI und Datenschutz" 
+- title: "KI und Datenschutz"
+  speakers:
+    - name: "Eckart Holzinger"
       img: "/img/speaker-avatars/eckart-holzinger.jpg"
 ---

--- a/_plauscherl/85.html
+++ b/_plauscherl/85.html
@@ -22,20 +22,25 @@ location:
         lat: 48.24086531900188
         lng: 14.234195755222851
 sponsor: <a href="https://www.tractive.com/">Tractive</a>
-speakers:
+talks:
+- title: "Statistical Insights into GPS Tracker Efficiency: Introducing the JuiceSpy System"
+  speakers:
     - name: "Alexander Tonino"
-      talk: "Statistical Insights into GPS Tracker Efficiency: Introducing the JuiceSpy System"
       img: "/img/speaker-avatars/alexander-tonino.jpg"
-      language: "en"
+  language: "en"
+- title: "Algorithmic Photo Books: Kotlin DSLs demystified"
+  speakers:
     - name: "Stefan Schöberl"
-      talk: "Algorithmic Photo Books: Kotlin DSLs demystified"
       img: "//schoeberl.dev/images/me.jpg"
-      language: "en"
+  language: "en"
+- title: "Bad Habits == Bad Code"
+  speakers:
     - name: "Christoph Kofler"
-      talk: "Bad Habits == Bad Code"
       img: "/img/speaker-avatars/chris-kofler.jpg"
-      language: "en"
-    - name: "Matthias Heiden and Alexander Peherstorfer"
-      talk: "From Code to Community: The Story of 0xA"
-      language: "en"
+  language: "en"
+- title: "From Code to Community: The Story of 0xA"
+  speakers:
+    - name: "Matthias Heiden"
+    - name: "Alexander Peherstorfer"
+  language: "en"
 ---

--- a/_plauscherl/86.html
+++ b/_plauscherl/86.html
@@ -23,20 +23,20 @@ location:
     lat: 48.31267908385208
     lng: 14.298413180167765
 sponsor: <a href="https://ubitec.at">Ubitec</a>
-speakers:
--
-   name: "Lukas Hubl"
-   talk: "Embedding based intent classification - on premise"
-   img: "/img/speaker-avatars/lukas-hubl.jpg"
-   language: "de"
--
-    name: "Katharina Wiesinger"
-    talk: "Making a difference in document management with Machine Learning"
-    img: "/img/speaker-avatars/katharina-wiesinger.jpg"
-    language: "de"
--
-    name: "Michael Hava"
-    talk: "Reflection in C++?!"
-    img: "/img/speaker-avatars/michael-hava.jpg"
-    language: "de"
+talks:
+- title: "Embedding based intent classification - on premise"
+  speakers:
+    - name: "Lukas Hubl"
+      img: "/img/speaker-avatars/lukas-hubl.jpg"
+  language: "de"
+- title: "Making a difference in document management with Machine Learning"
+  speakers:
+    - name: "Katharina Wiesinger"
+      img: "/img/speaker-avatars/katharina-wiesinger.jpg"
+  language: "de"
+- title: "Reflection in C++?!"
+  speakers:
+    - name: "Michael Hava"
+      img: "/img/speaker-avatars/michael-hava.jpg"
+  language: "de"
 ---

--- a/_plauscherl/87.html
+++ b/_plauscherl/87.html
@@ -23,24 +23,24 @@ location:
       lat: 48.24086531900188
       lng: 14.234195755222851
 sponsor: <a href="https://www.tractive.com/">Tractive</a>
-speakers:
--
-   name: "David Matousch"
-   talk: "The journey of creating DevTools for AB-Testing@Tractive"
-   language: "en"
--
-   name: "Rainer Stropek"
-   talk: "MCP, A2A, Integrations – AI Assistants discover the world"
-   img: "/img/speaker-avatars/rainer-stropek.jpg"
-   language: "en"
--
-   name: "Martin Forstner"
-   talk: "Accessibility Testing Isn't Rocket Science—or Is It?"
-   img: "/img/speaker-avatars/martin-forstner.jpg"
-   language: "en"
--
-   name: "Andrii Khrystian"
-   talk: "What is vibe coding and how to fight against it"
-   img: "/img/speaker-avatars/andrii-khrystian.jpeg"
-   language: "en"
+talks:
+- title: "The journey of creating DevTools for AB-Testing@Tractive"
+  speakers:
+    - name: "David Matousch"
+  language: "en"
+- title: "MCP, A2A, Integrations – AI Assistants discover the world"
+  speakers:
+    - name: "Rainer Stropek"
+      img: "/img/speaker-avatars/rainer-stropek.jpg"
+  language: "en"
+- title: "Accessibility Testing Isn't Rocket Science—or Is It?"
+  speakers:
+    - name: "Martin Forstner"
+      img: "/img/speaker-avatars/martin-forstner.jpg"
+  language: "en"
+- title: "What is vibe coding and how to fight against it"
+  speakers:
+    - name: "Andrii Khrystian"
+      img: "/img/speaker-avatars/andrii-khrystian.jpeg"
+  language: "en"
 ---

--- a/_plauscherl/88.html
+++ b/_plauscherl/88.html
@@ -23,27 +23,26 @@ location:
     lat: 48.303619026937284
     lng: 14.299148350489265
 sponsor: <a href="https://cloudflight.io">Cloudflight</a>
-speakers:
--
-   name: "John Uroko"
-   talk: "Using computer vision for early detection of cerebral palsy"
-   img: "/img/speaker-avatars/john-uroko.jpg"
-   language: "en"
--
-   name: "Markus Weninger"
-   talk: "JavaWiz: An Educational Graphical Debugger "
-   talklink: https://javawiz.net/
-   img: "/img/speaker-avatars/markus-weninger.png"
-   language: "en"
-- 
-   name: "Thomas Pollak"
-   talk: "PolyKybd: Displays In Your Keycaps"
-   img: "https://www.crowdsupply.com/avatar/a543aae7bb7916e72686548e3f543e58?s=196&r=g&d=mm"
-   language: "en"
-
-- 
-   name: "Wolfgang Ziegler"
-   talk: "Vienna Calling: What's New in Drupal's Universe"
-   img: "/img/speaker-avatars/wolfgang-ziegler.png"
-   language: "en"
+talks:
+- title: "Using computer vision for early detection of cerebral palsy"
+  speakers:
+    - name: "John Uroko"
+      img: "/img/speaker-avatars/john-uroko.jpg"
+  language: "en"
+- title: "JavaWiz: An Educational Graphical Debugger "
+  speakers:
+    - name: "Markus Weninger"
+      img: "/img/speaker-avatars/markus-weninger.png"
+  language: "en"
+  talklink: "https://javawiz.net/"
+- title: "PolyKybd: Displays In Your Keycaps"
+  speakers:
+    - name: "Thomas Pollak"
+      img: "https://www.crowdsupply.com/avatar/a543aae7bb7916e72686548e3f543e58?s=196&r=g&d=mm"
+  language: "en"
+- title: "Vienna Calling: What's New in Drupal's Universe"
+  speakers:
+    - name: "Wolfgang Ziegler"
+      img: "/img/speaker-avatars/wolfgang-ziegler.png"
+  language: "en"
 ---

--- a/_plauscherl/89.html
+++ b/_plauscherl/89.html
@@ -22,21 +22,21 @@ location:
       lat: 48.33730759276941
       lng: 14.315404854968783
 sponsor: <a href="https://www.fronius.com/de-at/austria">Fronius</a>
-speakers:
--
-   name: "Thomas Hüttner"
-   talk: "Fernsteuerung von Dezentralen Energieressourcen und Energienetze"
-   img: "/img/speaker-avatars/huettner-thomas.jpg"
-   language: "de"
--
-   name: "Markus Weninger"
-   talk: "Kotlin Compiler Plugin Development (for Compile Time Code Instrumentation)"
-   talklink: https://ssw.jku.at/General/Staff/Weninger/
-   img: "/img/speaker-avatars/markus-weninger.png"
-   language: "en"
--
-   name: "Daniel Knittl-Frank"
-   talk: "Load test your applications with Grafana k6"
-   img: "/img/speaker-avatars/daniel-knittl-frank.png"
-   language: "en"
+talks:
+- title: "Fernsteuerung von Dezentralen Energieressourcen und Energienetze"
+  speakers:
+    - name: "Thomas Hüttner"
+      img: "/img/speaker-avatars/huettner-thomas.jpg"
+  language: "de"
+- title: "Kotlin Compiler Plugin Development (for Compile Time Code Instrumentation)"
+  speakers:
+    - name: "Markus Weninger"
+      img: "/img/speaker-avatars/markus-weninger.png"
+  language: "en"
+  talklink: "https://ssw.jku.at/General/Staff/Weninger/"
+- title: "Load test your applications with Grafana k6"
+  speakers:
+    - name: "Daniel Knittl-Frank"
+      img: "/img/speaker-avatars/daniel-knittl-frank.png"
+  language: "en"
 ---

--- a/_plauscherl/90.html
+++ b/_plauscherl/90.html
@@ -23,21 +23,21 @@ location:
     lat: 48.31267908385208
     lng: 14.298413180167765
 sponsor: <a href="https://ubitec.at/">Ubitec</a>
-speakers:
--
-   name: "Martin Sereinig"
-   talk: "Postgres, aber als Message Broker"
-   abstract: "Warum – und wie – wir RabbitMQ mit Postgres ersetzt haben."
-   img: "/img/speaker-avatars/martin-sereinig.jpg"
-   language: "de"
--
-   name: "Jailan Rashed"
-   talk: "Building lovable SaaS products"
-   abstract: "The Power of User Journeys Over Features – In the competitive SaaS lanscape, solving problems is the baseline. The secret? Shifting the focus from isolated features to cohesive, value-driven user journeys."
-   img: "/img/speaker-avatars/jailan-rashed.jpeg"
-   language: "en"
--
-   name: "Klaus Linzner"
-   talk: "Migrating legacy services to gitops kubernetes"
-   language: "de"
+talks:
+- title: "Postgres, aber als Message Broker"
+  speakers:
+    - name: "Martin Sereinig"
+      img: "/img/speaker-avatars/martin-sereinig.jpg"
+  language: "de"
+  abstract: "Warum – und wie – wir RabbitMQ mit Postgres ersetzt haben."
+- title: "Building lovable SaaS products"
+  speakers:
+    - name: "Jailan Rashed"
+      img: "/img/speaker-avatars/jailan-rashed.jpeg"
+  language: "en"
+  abstract: "The Power of User Journeys Over Features – In the competitive SaaS lanscape, solving problems is the baseline. The secret? Shifting the focus from isolated features to cohesive, value-driven user journeys."
+- title: "Migrating legacy services to gitops kubernetes"
+  speakers:
+    - name: "Klaus Linzner"
+  language: "de"
 ---

--- a/_plauscherl/91.html
+++ b/_plauscherl/91.html
@@ -22,25 +22,25 @@ location:
       lat: 48.305746106259946
       lng: 14.310553947331162
 sponsor: <a href="https://www.dynatrace.com/">Dynatrace</a>
-speakers:
--
-   name: "Manuel Wiltz"
-   talk: "AI Coding Assistants: Auswirkungen auf Kollaboration und Knowledge Sharing in Software-Engineering-Teams"
-   img: "/img/speaker-avatars/manuel-wiltz.jpg"
-   language: "de"
--
-   name: "Benedikt Werner"
-   talk: "4*2=7 - Debugging des Bosch ESD Car 2.0 - ein selbstfahrendes Auto als Semesterprojekt"
-   img: "/img/speaker-avatars/benedikt-werner.jpg"
-   language: "de"
--
-   name: "Robert Koeppe"
-   talk: "How to bring electronic functionalities closer to the human body - from CAD to functional wearable device"
-   img: "/img/speaker-avatars/robert-koeppe.jpg"
-   language: "en"
--
-   name: "Michael Lanzinger"
-   talk: "NetzBeweis"
-   img: "/img/speaker-avatars/michael_lanzinger.jpg"
-   language: "de"
+talks:
+- title: "AI Coding Assistants: Auswirkungen auf Kollaboration und Knowledge Sharing in Software-Engineering-Teams"
+  speakers:
+    - name: "Manuel Wiltz"
+      img: "/img/speaker-avatars/manuel-wiltz.jpg"
+  language: "de"
+- title: "4*2=7 - Debugging des Bosch ESD Car 2.0 - ein selbstfahrendes Auto als Semesterprojekt"
+  speakers:
+    - name: "Benedikt Werner"
+      img: "/img/speaker-avatars/benedikt-werner.jpg"
+  language: "de"
+- title: "How to bring electronic functionalities closer to the human body - from CAD to functional wearable device"
+  speakers:
+    - name: "Robert Koeppe"
+      img: "/img/speaker-avatars/robert-koeppe.jpg"
+  language: "en"
+- title: "NetzBeweis"
+  speakers:
+    - name: "Michael Lanzinger"
+      img: "/img/speaker-avatars/michael_lanzinger.jpg"
+  language: "de"
 ---

--- a/_sass/modules/_speaker.scss
+++ b/_sass/modules/_speaker.scss
@@ -16,19 +16,85 @@
 
 .speaker {
 	text-align: center;
-	display: table;
+	display: block;
 	width: 100%;
 	position: relative;
+}
+
+.talk {
+	text-align: center;
+	display: block;
+	width: 100%;
+	position: relative;
+	padding: 0 0 1.5rem;
+}
+
+.speakers--talks {
+	align-items: center;
+}
+
+.talk__header {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: flex-start;
+	min-height: 5.2rem;
+	margin-top: 0.75rem;
+}
+
+.talk__title {
+	margin: 0;
+	font-size: 1.1rem;
+	line-height: 1.3;
+}
+
+.talk__language {
+	display: block;
+	margin: 0.35rem auto 0;
+}
+
+.talk__speakers {
+	list-style: none;
+	margin: 0;
+	padding: 0;
+	display: flex;
+	flex-wrap: wrap;
+	justify-content: center;
+	gap: 1.5rem;
+}
+
+.talk__speaker {
+	display: block;
+	min-width: 130px;
+}
+
+.talk__speaker-img {
+	border-radius: 50%;
+	width: 90px;
+	height: 90px;
+	display: inline-block;
+	object-fit: cover;
+}
+
+.talk--many-speakers .talk__speaker-img {
+	width: 78px;
+	height: 78px;
+}
+
+.talk__speaker-name {
+	display: block;
+	font-weight: 600;
+	padding-top: 0.5rem;
 }
 
 .speaker__img {
 	border-radius: 50%;
 
-	width: 100px;
-	height: 100px;
-	display: table-cell;
+	width: 90px;
+	height: 90px;
+	display: inline-block;
 	vertical-align: middle;
-	margin-right: 1.5rem;
+	margin-right: 0;
 	object-fit: cover;
 }
 
@@ -45,10 +111,10 @@
 }
 
 .speaker__info {
-	display: table-cell;
+	display: block;
 	vertical-align: middle;
 	width: 100%;
-	padding: 10px;
+	padding: 10px 0 0;
 	box-sizing: border-box;
 }
 
@@ -116,6 +182,15 @@
 		padding: 0 1rem;
 	}
 
+	.talk {
+		flex: 1;
+		padding: 0 1rem 2rem;
+	}
+
+	.speakers--talks {
+		align-items: center;
+	}
+
 	.speakers--stats .speaker {
 		flex-basis: 180px;
 	}
@@ -129,8 +204,18 @@
 	.speaker__img {
 		display: inline-block;
 		margin-right: 0;
-		width: 160px;
-		height: 160px;
+		width: 130px;
+		height: 130px;
+	}
+
+	.talk__speaker-img {
+		width: 130px;
+		height: 130px;
+	}
+
+	.talk--many-speakers .talk__speaker-img {
+		width: 112px;
+		height: 112px;
 	}
 
 	.speaker__info {

--- a/_sass/modules/_speaker.scss
+++ b/_sass/modules/_speaker.scss
@@ -42,6 +42,14 @@
 	margin-top: 0.75rem;
 }
 
+.talk__title-row {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	gap: 0.5rem;
+	flex-wrap: wrap;
+}
+
 .talk__title {
 	margin: 0;
 	font-size: 1.1rem;
@@ -51,6 +59,54 @@
 .talk__language {
 	display: block;
 	margin: 0.35rem auto 0;
+}
+
+.talk__abstract-details {
+	display: inline-block;
+	position: relative;
+}
+
+.talk__abstract-summary {
+	list-style: none;
+	cursor: pointer;
+	display: inline-flex;
+	align-items: center;
+	padding: 0;
+	margin: 0;
+}
+
+.talk__abstract-summary:focus {
+	outline: 0.125rem solid #49c096;
+	outline-offset: 0.125rem;
+	border-radius: 0.125rem;
+}
+
+.talk__abstract-icon {
+	width: 1rem;
+	height: 1rem;
+}
+
+.talk__abstract {
+	position: fixed;
+	top: 50%;
+	left: 1rem;
+	right: 1rem;
+	transform: translateY(-50%);
+	background-color: #fff;
+	border: 0.25rem solid #ddd;
+	border-radius: 0.25rem;
+	padding: 0.75rem 1rem;
+	z-index: 100;
+	box-shadow: 0 0.125rem 0.5rem rgba(0, 0, 0, 0.1);
+	font-size: 0.875rem;
+	line-height: 1.5;
+	color: #333;
+	text-shadow: none;
+	text-align: left;
+}
+
+.talk__link {
+	margin: 0.5rem 0 0;
 }
 
 .talk__speakers {
@@ -216,6 +272,17 @@
 	.talk--many-speakers .talk__speaker-img {
 		width: 112px;
 		height: 112px;
+	}
+
+	.talk__abstract {
+		position: absolute;
+		top: 100%;
+		left: 50%;
+		right: auto;
+		transform: translateX(-50%);
+		margin-top: 0.5rem;
+		max-width: 20rem;
+		min-width: 15rem;
 	}
 
 	.speaker__info {

--- a/feed.xml
+++ b/feed.xml
@@ -13,9 +13,11 @@ layout: none
       <item>
         <title>{{ post.title | xml_escape }} | {{ post.startDateIso8601 | date: "%Y-%m-%d %H:%M" }} @ {{post.location.name | xml_escape }}</title>
         <description>
-          {% for speaker in post.speakers %}
-            {{ speaker.name | xml_escape }}: {{ speaker.talk | xml_escape }}
+          {% for talk in post.talks %}
+            {% for speaker in talk.speakers %}
+            {{ speaker.name | xml_escape }}: {{ talk.title | xml_escape }}
             <![CDATA[<br />]]>
+            {% endfor %}
           {% endfor %}
         </description>
         <link>{{ post.url | prepend: site.baseurl | prepend: site.url }}</link>

--- a/pages/stats.html
+++ b/pages/stats.html
@@ -13,23 +13,25 @@ permalink: /stats/
 	{% assign speaker_counts = "" -%}
 	
 	{% for event in site.plauscherl -%}
-		{% for speaker in event.speakers -%}
-			{% if speaker.name -%}
-				{% assign names = speaker.name | split: "&" -%}
-				{% assign img = speaker.img -%}
-				{% if names.size > 1 -%}
-					{% assign img = "" -%}{% comment -%}Ignore shared images{% endcomment -%}
-				{% endif -%}
-				
-				{% for n in names -%}
-					{% assign stripped_name = n | strip -%}
-					{% comment -%}Handle name changes via _data/speaker_aliases.yml{% endcomment -%}
-					{% if site.data.speaker_aliases[stripped_name] -%}
-						{% assign stripped_name = site.data.speaker_aliases[stripped_name] -%}
+		{% for talk in event.talks -%}
+			{% for speaker in talk.speakers -%}
+				{% if speaker.name -%}
+					{% assign names = speaker.name | split: "&" -%}
+					{% assign img = speaker.img -%}
+					{% if names.size > 1 -%}
+						{% assign img = "" -%}{% comment -%}Ignore shared images{% endcomment -%}
 					{% endif -%}
-					{% assign speaker_counts = speaker_counts | append: stripped_name | append: "|||" | append: img | append: ":::" -%}
-				{% endfor -%}
-			{% endif -%}
+					
+					{% for n in names -%}
+						{% assign stripped_name = n | strip -%}
+						{% comment -%}Handle name changes via _data/speaker_aliases.yml{% endcomment -%}
+						{% if site.data.speaker_aliases[stripped_name] -%}
+							{% assign stripped_name = site.data.speaker_aliases[stripped_name] -%}
+						{% endif -%}
+						{% assign speaker_counts = speaker_counts | append: stripped_name | append: "|||" | append: img | append: ":::" -%}
+					{% endfor -%}
+				{% endif -%}
+			{% endfor -%}
 		{% endfor -%}
 	{% endfor -%}
 


### PR DESCRIPTION
Adds proper support for multiple speakers on a single talk. (requested in #249 )
This required some restructuring of the data provided in the individual Plauscherl sites.
For certain multi-speaker talks, I split them. For others I kept it as is as they shared  a single image 

For a single speaker on a topic, nothing changes. For topics with more speakers, the talk title and language is shared. For talks [with 3 or more speakers](https://github.com/technologieplauscherl/technologieplauscherl.github.io/pull/350/changes/6a391e302d5b35e37ddf3d3df232900388cc8c76#diff-d2a0376f30f122c1bcb3eeaf7a06efa07638b0b295ddb0bc8c68a3113c4b2d47R9), the image is reduced in size improve space usage

<img width="1680" height="607" alt="grafik" src="https://github.com/user-attachments/assets/a5773036-91eb-48ec-a96b-06c6367b132c" />


<img width="1680" height="782" alt="grafik" src="https://github.com/user-attachments/assets/49964f2d-c564-4c0d-9854-38ef47bb26fe" />  
*the second talk line-up is just for showing the multi-speaker setup with many speakers on a single topic
