### PR TITLE
Show past events in archive based on timestamp

### DIFF
--- a/pages/archiv.html
+++ b/pages/archiv.html
@@ -6,9 +6,12 @@ og_description: "Alle vergangenen Veranstaltungen des Technologieplauscherls auf
 ---
 
 <div class="cards">
-{% for card in site.plauscherl reversed %}
-{% unless forloop.first %}
-{% include plauscherl-card.html %}
-{% endunless %}
-{% endfor %}
+{% assign buildTimeInSecondsInEpoch = site.time | date: "%s" | plus: 0 -%}
+{% for card in site.plauscherl reversed -%}
+{% assign cardTimeInSecondsInEpoch = card.startDateIso8601 | date: "%s" | plus: 0 -%}
+	{% comment -%} Only show past events in the archive based on the current time and event timestamp {% endcomment -%}
+	{% if cardTimeInSecondsInEpoch < buildTimeInSecondsInEpoch -%}
+	{% include plauscherl-card.html -%}
+	{% endif -%}
+{% endfor -%}
 </div>


### PR DESCRIPTION
Instead of hard-codedly skipping the most recent plauscherl, it will only be skipped if the page is built, and it didn't happen yet.

Currently, the 91st plauscherl is not showing up, because of the [`unless forloop.first`](https://github.com/technologieplauscherl/technologieplauscherl.github.io/blob/3f6ae18d873b2e6452a9cba7df5d1c2f8163b250/pages/archiv.html#L10).
With the adjustments, it shows up in the archive as it already happened. If the timestamp is updated to be in the future, then it would not be included.