### PR TITLE
Improve speaker talk formatting

### DIFF
--- a/_includes/speakers.html
+++ b/_includes/speakers.html
@@ -1,9 +1,108 @@
+{% comment -%}
+Places speakers in a table-like layout in the following style:
+| Speakers 1 | Speakers 2 | Speakers 3 |
+| Title 1    | Title 2    | Title 3    |
+| Language 1 | Language 2 | Language 3 |
+
+The individual cells are centered and speaker images are reduced in size if
+there are multiple speakers for a given talk.
+{% endcomment -%}
+
 {% assign talks_source = include.post | default: post | default: page %}
 {% if talks_source.talks and talks_source.talks != empty %}
-<div class="speakers speakers--talks" aria-label="Vorträge">
-  {% for talk in talks_source.talks %}
-    {% include talk.html talk=talk %}
-  {% endfor %}
+<div class="speakers speakers--talks talks-table-wrapper" aria-label="Vorträge">
+  <table class="talks-table" role="presentation">
+    <tbody>
+      <tr class="talks-table__row talks-table__row--speakers">
+        {% for talk in talks_source.talks %}
+          {% assign speaker_count = 0 %}
+          {% if talk.speakers and talk.speakers != empty %}
+            {% assign speaker_count = talk.speakers | size %}
+          {% elsif talk.speaker and talk.speaker != empty %}
+            {% assign speaker_count = 1 %}
+          {% endif %}
+          <td class="talks-table__cell talks-table__cell--speakers">
+            <div class="talks-table__cell-inner">
+              <ul class="talks-table__speakers" aria-label="Speakers">
+                {% if talk.speakers and talk.speakers != empty %}
+                  {% for speaker in talk.speakers %}
+                    <li class="talks-table__speaker" itemprop="contributor" itemscope itemtype="https://schema.org/Person">
+                      <img
+                        {% if speaker.img == empty -%}
+                          src="/img/speaker_no_image.jpg"
+                        {% else -%}
+                          src="{{speaker.img}}"
+                        {% endif -%}
+                        alt="{{speaker.name}}"
+                        class="talk__speaker-img{% if speaker_count > 2 %} talks-table__speaker-img--small{% endif %}"
+                        onerror="if (!this.src.endsWith('_no_image.png')) this.src = '/img/speaker_no_image.jpg'">
+                      <span class="talk__speaker-name" itemprop="name">{{speaker.name}}</span>
+                    </li>
+                  {% endfor %}
+                {% elsif talk.speaker and talk.speaker != empty %}
+                  <li class="talks-table__speaker" itemprop="contributor" itemscope itemtype="https://schema.org/Person">
+                    <img
+                      {% if talk.speaker.img == empty -%}
+                        src="/img/speaker_no_image.jpg"
+                      {% else -%}
+                        src="{{talk.speaker.img}}"
+                      {% endif -%}
+                      alt="{{talk.speaker.name}}"
+                      class="talk__speaker-img"
+                      onerror="if (!this.src.endsWith('_no_image.png')) this.src = '/img/speaker_no_image.jpg'">
+                    <span class="talk__speaker-name" itemprop="name">{{talk.speaker.name}}</span>
+                  </li>
+                {% endif %}
+              </ul>
+            </div>
+          </td>
+        {% endfor %}
+      </tr>
+
+      <tr class="talks-table__row talks-table__row--titles">
+        {% for talk in talks_source.talks %}
+          <td class="talks-table__cell talks-table__cell--title" itemprop="name">
+            <div class="talks-table__cell-inner">
+              <div class="talk__title-row">
+                <h3 class="talk__title">{{ talk.talk | default: talk.title }}</h3>
+                {% if talk.abstract and talk.abstract != empty %}
+                  <details class="talk__abstract-details">
+                    <summary class="talk__abstract-summary" aria-label="Abstract for {{ talk.talk | default: talk.title }}">
+                      <svg class="talk__abstract-icon" aria-hidden="true">
+                        <use xlink:href="#icon-info-circle"></use>
+                      </svg>
+                    </summary>
+                    <div class="talk__abstract" role="tooltip">
+                      {{ talk.abstract }}
+                    </div>
+                  </details>
+                {% endif %}
+              </div>
+              {% if talk.talklink and talk.talklink != empty %}
+                <p class="talk__link">
+                  <a href="{{ talk.talklink }}">Slides/Link</a>
+                </p>
+              {% endif %}
+            </div>
+          </td>
+        {% endfor %}
+      </tr>
+
+      <tr class="talks-table__row talks-table__row--languages">
+        {% for talk in talks_source.talks %}
+          <td class="talks-table__cell talks-table__cell--language">
+            <div class="talks-table__cell-inner">
+              {% if talk.language == "en" %}
+                <img class="talk__language" src="/img/english-language.svg" width="40" height="20" alt="Talk is in English" title="Talk is in English">
+              {% else %}
+                <img class="talk__language" src="/img/german-language.svg" width="40" height="20" alt="Talk is in German" title="Talk is in German">
+              {% endif %}
+            </div>
+          </td>
+        {% endfor %}
+      </tr>
+    </tbody>
+  </table>
 {% else %}
 <div class="speakers" aria-label="Vorträge">
   {% assign speaker_list = talks_source.speakers | default: talks_source.speaker %}

--- a/_includes/speakers.html
+++ b/_includes/speakers.html
@@ -21,7 +21,7 @@ there are multiple speakers for a given talk.
           {% elsif talk.speaker and talk.speaker != empty %}
             {% assign speaker_count = 1 %}
           {% endif %}
-          <td class="talks-table__cell talks-table__cell--speakers">
+          <td class="talks-table__cell talks-table__cell--speakers" style="order: {{ forloop.index }}0;">
             <div class="talks-table__cell-inner">
               <ul class="talks-table__speakers" aria-label="Speakers">
                 {% if talk.speakers and talk.speakers != empty %}
@@ -61,7 +61,7 @@ there are multiple speakers for a given talk.
 
       <tr class="talks-table__row talks-table__row--titles">
         {% for talk in talks_source.talks %}
-          <td class="talks-table__cell talks-table__cell--title" itemprop="name">
+          <td class="talks-table__cell talks-table__cell--title" itemprop="name" style="order: {{ forloop.index }}1;">
             <div class="talks-table__cell-inner">
               <div class="talk__title-row">
                 <h3 class="talk__title">{{ talk.talk | default: talk.title }}</h3>
@@ -90,7 +90,7 @@ there are multiple speakers for a given talk.
 
       <tr class="talks-table__row talks-table__row--languages">
         {% for talk in talks_source.talks %}
-          <td class="talks-table__cell talks-table__cell--language">
+          <td class="talks-table__cell talks-table__cell--language" style="order: {{ forloop.index }}2;">
             <div class="talks-table__cell-inner">
               {% if talk.language == "en" %}
                 <img class="talk__language" src="/img/english-language.svg" width="40" height="20" alt="Talk is in English" title="Talk is in English">

--- a/_sass/modules/_speaker.scss
+++ b/_sass/modules/_speaker.scss
@@ -30,7 +30,51 @@
 }
 
 .speakers--talks {
+	display: block;
+}
+
+.talks-table-wrapper {
+	overflow-x: auto;
+}
+
+.talks-table {
+	width: 100%;
+	table-layout: fixed;
+	border-collapse: collapse;
+}
+
+.talks-table__cell {
+	width: 1%;
+	padding: 0.75rem;
+	text-align: center;
+	vertical-align: middle;
+}
+
+.talks-table__cell-inner {
+	display: flex;
+	flex-direction: column;
 	align-items: center;
+	gap: 0.25rem;
+}
+
+.talks-table__speakers {
+	list-style: none;
+	margin: 0;
+	padding: 0;
+	display: flex;
+	justify-content: center;
+	align-items: flex-start;
+	flex-wrap: wrap;
+	gap: 1rem;
+}
+
+.talks-table__speaker {
+	min-width: 7rem;
+}
+
+.talks-table__speaker-img--small {
+	width: 112px;
+	height: 112px;
 }
 
 .talk__header {
@@ -244,7 +288,7 @@
 	}
 
 	.speakers--talks {
-		align-items: center;
+		display: block;
 	}
 
 	.speakers--stats .speaker {

--- a/_sass/modules/_speaker.scss
+++ b/_sass/modules/_speaker.scss
@@ -77,6 +77,41 @@
 	height: 112px;
 }
 
+@media(max-width: 499px) {
+	.talks-table-wrapper {
+		overflow-x: visible;
+	}
+	.talks-table {
+		display: grid;
+		grid-template-columns: 1fr auto;
+		column-gap: 0.5rem;
+		align-items: center;
+	}
+	.talks-table tbody, .talks-table__row {
+		display: contents;
+	}
+	.talks-table__cell {
+		width: auto;
+		padding: 0;
+	}
+	.talks-table__cell--speakers {
+		grid-column: 1 / -1;
+		margin-top: 2.5rem;
+	}
+	.talks-table__cell--language {
+		justify-content: flex-end;
+		align-items: flex-end;
+	}
+	.talks-table__cell--title .talks-table__cell-inner {
+		align-items: center;
+		justify-content: center;
+		text-align: center;
+	}
+	.talk__title-row {
+		justify-content: center;
+	}
+}
+
 .talk__header {
 	display: flex;
 	flex-direction: column;


### PR DESCRIPTION

Multi-speaker view currently cannot handle the various height/width differences properly.
**Desktop:** 
As an example, the view for Plauscherl 92 has the languages seemingly randomly placed without consistency to the other talks. Then, the 1st and 4th talk are on the same level (for having two speakers), but the 3rd talk's speakers are slightly higher placed because of the longer talk title.
<img width="1071" height="606" alt="grafik" src="https://github.com/user-attachments/assets/e11080a0-f36d-49be-b48f-0acee3878850" />

With my changes the speakers are placed more in a grid-like view, which makes spacings way more consistent and evenly spaced.
<img width="1081" height="582" alt="grafik" src="https://github.com/user-attachments/assets/1465569a-c982-482a-8fae-525119c08088" />
If enough horizontal space is present, then the speakers will be put besides each other, instead of above/below
<img width="1153" height="388" alt="grafik" src="https://github.com/user-attachments/assets/b4cc48d7-c75a-40fb-bd5f-47273cbec343" /> 

**Mobile:** (i.e. narrow portrait screens)

Similar inconsistencies can be seen on narrow screens where for some reason css puts speakers either side-to-side or below each other:
<img width="1080" height="2340" alt="Bildschirmfoto am 2026-04-17 um 15 29 05" src="https://github.com/user-attachments/assets/c9b44bd7-7758-4f6f-b455-3ca151fd1450" />
<img width="1080" height="2340" alt="Bildschirmfoto am 2026-04-17 um 15 29 14" src="https://github.com/user-attachments/assets/b514474b-0f88-45b4-b374-72c1661cad58" />

With the changes this also improves by always displaying speakers next to each other, and the title + language being below it
<img width="1080" height="2340" alt="Bildschirmfoto am 2026-04-17 um 15 31 33" src="https://github.com/user-attachments/assets/f8ff031f-9098-4a5b-bb7e-7c4202418275" />


With e.g. four speakers the mobile view looks like this:
<img width="404" height="424" alt="grafik" src="https://github.com/user-attachments/assets/2f3d3d8e-6c42-4352-bb74-b946d3e20c77" />

