### PR TITLE
Fix generation of speakers list in ics

### DIFF
--- a/events.ics
+++ b/events.ics
@@ -23,7 +23,20 @@ DTSTAMP:{{ post.startDateIso8601 | date: "%Y%m%dT%H%M%S" }}Z
 URL:{{ post.url | prepend: site.baseurl | prepend: site.url }}
 DESCRIPTION:URL: {{ post.url | prepend: site.baseurl | prepend: site.url }}\n
   \nLocation: {{post.location.name}} {{location_fmt}}\n
-  \nSpeakers:\n{% for speaker in post.speakers %}{{speaker.name}}
-  \n{{speaker.talk}}{% unless forloop.last %}\n\n{% endunless %}{% endfor %}
+  \nSpeakers:\n
+  {%- if post.talks and post.talks != empty -%}
+    {%- for talk in post.talks -%}
+      {%- for speaker in talk.speakers -%}
+{{ speaker.name }}{%- unless forloop.last -%}, {% endunless -%}
+      {%- endfor -%}\n{{ talk.title }}
+      {%- unless forloop.last -%}\n\n{% endunless -%}
+    {%- endfor -%}
+  {%- else -%}
+    {%- assign speaker_list = post.speakers | default: post.speaker -%}
+    {%- for speaker in speaker_list -%}
+{{speaker.name}}\n{{speaker.talk}}
+      {%- unless forloop.last -%}\n\n{% endunless -%}
+    {%- endfor -%}
+  {%- endif %}
 END:VEVENT{% endif %}{% endfor %}
 END:VCALENDAR


### PR DESCRIPTION
It broke when multi-speaker support changed the data structuring.

After it broke the event description was:
```
...
DESCRIPTION:URL: https://technologieplauscherl.at/92/\n
  \nLocation: Smarter Ecommerce (SMEC) Peter-Behrens-Platz 9, 4020 Linz\n
  \nSpeakers:\n
END:VEVENT
```

With the fix it now is:
```
...
DESCRIPTION:URL: https://technologieplauscherl.at/92/\n
  \nLocation: Smarter Ecommerce (SMEC) Peter-Behrens-Platz 9, 4020 Linz\n
  \nSpeakers:\nChristian Gintenreiter, Alexander Munz\nBeyond AI First: Balancing AI Innovation with Proven Processes to Empower Our Colleagues\n\nMarkus Vogl\nVibe hacking for CTFs\n\nMarkus Gutenberger, Andreas Schachl\nFrom Data to Decisions: Building Reliable Surveillance AI through High-Quality Annotation\n\nErnst Leitner, Martin Tschemernjak\nEnd-2-End KI-Einsatz in der Enterprise Software Entwicklung
END:VEVENT
```

This description will be displayed as shown below, which is similar to the style before breaking it.
> URL: https://technologieplauscherl.at/92/
> 
> Location: Smarter Ecommerce (SMEC) Peter-Behrens-Platz 9, 4020 Linz
> 
> Speakers:
> Christian Gintenreiter, Alexander Munz
> Beyond AI First: Balancing AI Innovation with Proven Processes to Empower Our Colleagues
> 
> Markus Vogl
> Vibe hacking for CTFs
> 
> Markus Gutenberger, Andreas Schachl
> From Data to Decisions: Building Reliable Surveillance AI through High-Quality Annotation
> 
> Ernst Leitner, Martin Tschemernjak
> End-2-End KI-Einsatz in der Enterprise Software Entwicklung
