### PR TITLE
Auto-generate Opengraph description for plauscherl

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,11 +1,17 @@
 <head>
 	{% assign meta_title = page.title | default: site.title -%}
-	{% assign meta_description = page.og_description | default: site.description -%}
+	{% assign meta_description = site.description -%}
 	{% assign additional_image = page.og_image | default: '' -%}
 	{% comment -%}
 		In addition to the default image, specify a page-specific image if on a plauscherl-page (e.g. technologieplauscherl.at/91)
 	{% endcomment -%}
 	{% if page.layout == "post" -%}
+		{% comment -%}
+			Construct a meta description for plauscherl pages, e.g. "Technologieplauscherl am 12.12.2024 bei ... in ..."}
+		{% endcomment -%}
+		{% assign event_location_name = page.location.name | default: '' -%}
+		{% assign event_location_city = page.location.city | default: '' -%}
+		{% assign meta_description = 'Technologieplauscherl am ' | append: page.datestring | append: ' bei ' | append: event_location_name | append: ' in ' | append: event_location_city -%}
 		{% assign event_image_name = page.name | split: '.' | first -%}
 		{% assign event_image = '/img/plauscherle/' | append: event_image_name | append: '.webp' -%}
 		{% assign event_image_file = site.static_files | where: 'path', event_image -%}
@@ -13,6 +19,11 @@
 			{% assign additional_image = event_image | absolute_url -%}
 		{% endif -%}
 	{% endif -%}
+	
+	{% comment -%}
+		Rank a page specific description as the highest priority
+	{% endcomment -%}
+	{% assign meta_description = page.og_description | default: meta_description -%}
 
 	<meta charset="UTF-8">
 	<title>{{ meta_title | escape }}</title>


### PR DESCRIPTION
The description generation priority is as follows (highest to lowest):
1. page-specific `meta_description`
2. auto-generated event description (only for post layouts, i.e. plauscherl)
3. Fall back to _config.yaml's global description

Currently a plauscherl Opengraph description shows up like this:
<img width="541" height="367" alt="grafik" src="https://github.com/user-attachments/assets/4d617ae5-4210-47d9-a42f-e0f82dc84d5a" />

With the changes it would look like this:
<img width="541" height="367" alt="grafik" src="https://github.com/user-attachments/assets/46e8c2b6-c285-4c41-8a0c-2cb7355a4b21" />
