### PR TITLE
Open linked community news in new tab

### DIFF
--- a/_includes/communitynews.html
+++ b/_includes/communitynews.html
@@ -16,7 +16,7 @@
 {% endcase %}
 {% endcapture %}
 {% unless include.news.link == null %}
-<a href="{{include.news.link}}" class="event">
+<a href="{{include.news.link}}" class="event" target="_blank" rel="noopener">
 {% else %}
 <span class="event">
 {% endunless %}


### PR DESCRIPTION
I think for such a list of events it makes sense to open in a new tab. Is just easier to get back to our list after browsing the referenced page for some time.