### PR TITLE
Add compose for local building

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -1,0 +1,16 @@
+services:
+  site:
+    image: ghcr.io/actions/jekyll-build-pages
+    container_name: gh_page
+    working_dir: /github/workspace
+    environment:
+      INPUT_SOURCE: .
+      INPUT_DESTINATION: _site
+      GITHUB_WORKSPACE: /github/workspace
+    entrypoint: ["jekyll"]
+    command: ["serve", "--livereload", "--incremental", "--host", "0.0.0.0"]
+    ports:
+      - "4000:4000"
+      - "35729:35729" # Livereload port
+    volumes:
+      - ./:/github/workspace:rw


### PR DESCRIPTION
Utilizes officlal image used by github pages

Installing jekyll it self via gem or so is more hit/miss. (Already had it randomly break because of missing ruby stuff). This makes it way easier to run a server.