### PR TITLE
[TP93] Add info about postponed event

### DIFF
--- a/_data/community.yml
+++ b/_data/community.yml
@@ -27,18 +27,10 @@
 -   id: technologieplauscherl
     name: "Technologieplauscherl"
     events:
-        -   name: "Technologieplauscherl 91"
-            location: Litec - HTL Paul-Hahn
-            date: 2026-03-24
-            link: https://technologieplauscherl.at
-        -   name: "Technologieplauscherl 92"
-            location: Smarter Ecommerce
-            date: 2026-05-07
-            link: https://technologieplauscherl.at/92
         -   name: "Technologieplauscherl 93"
-            location: TBC
             date: 2026-06-25
-            link: https://technologieplauscherl.at
+            link: https://technologieplauscherl.at/93/
+            additionalInfo: "Termin verschoben"
 -   id: agilecomm
     name: "Agile Community Linz"
     events:

--- a/_includes/communitynews.html
+++ b/_includes/communitynews.html
@@ -30,10 +30,15 @@
       {% if include.news.cost -%}
       <svg class="event__icon event__icon--cost"><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-coin-euro"></use></svg>
       {% endif -%}
+      {% if include.news.location -%}
       <div class="event__venue" itemprop="location" itemscope itemtype="https://schema.org/Place">
         <svg class="event__icon icon"><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-compass2"></use></svg>
         <span itemprop="name">{{include.news.location}}</span>
       </div>
+      {% endif -%}
+      {% if include.news.additionalInfo -%}
+      <div class="event__additional-info">{{ include.news.additionalInfo }}</div>
+      {% endif -%}
     </div>
   </div>
 {% unless include.news.link == null -%}

--- a/_includes/masthead.html
+++ b/_includes/masthead.html
@@ -1,11 +1,13 @@
-<div class="masthead">
+{% assign post = site.plauscherl | last -%}
+
+<div class="masthead{% if post.layout == "page" %} masthead--plain{% endif %}">
 	<div class="top">
 		<h1 itemprop="name">Technologieplauscherl</h1>
 	</div>
 
-	{% assign post = site.plauscherl | last -%}
-
 	<div class="bottom">
+		{% if post.layout == "post" -%}
+
 		{% if post.video -%}
             <iframe class="livestream" width="900" height="500" src="https://www.youtube.com/embed/{{post.video}}?ecver=1" frameborder="0" allowfullscreen></iframe>
 		{% endif -%}
@@ -69,6 +71,9 @@
 				</script>
 			{% endunless -%}
 		</p>
+		{% else if post.layout == "page" -%}
+			{{ post.content }}
+		{% endif -%}
 
 		{% if include.ended -%}
 		<a href="https://www.linkedin.com/groups/12659872/" target="_blank" class="link link--big link--linkedin">

--- a/_plauscherl/93.html
+++ b/_plauscherl/93.html
@@ -1,0 +1,25 @@
+---
+title: "Technologieplauscherl XCIII"
+permalink: /93/
+name: 93
+layout: page
+---
+<h2>Verschoben</h2>
+
+<span class="info">
+  <p>
+  Liebe Technologieplauscherl-Community,
+  </p>
+  <p>
+  leider müssen wir den Termin des 93. Technologieplauscherls verschieben. Das nächste Technologieplauscherl wird voraussichtlich nach der Sommerpause im September stattfinden. Den genauen Termin geben wir rechtzeitig bekannt.
+  </p>
+
+  <p>
+  Wir wünschen euch bis dahin einen schönen und erholsamen Sommer!
+  </p>
+
+  <p>
+  Eure Technologieplauscherl-Organisatoren
+  </p>
+</span>
+

--- a/_sass/modules/_masthead.scss
+++ b/_sass/modules/_masthead.scss
@@ -11,6 +11,21 @@
 	color: #fff;
 }
 
+.masthead--plain {
+    background-image: none;
+    background-color: rgba(0, 0, 0, 0.5);
+	position: relative;
+	width: 100%;
+	text-shadow: 0 0 10px rgba(0,0,0,1);
+	position: relative;
+	text-align: center;
+	color: #fff;
+}
+
+.masthead--plain:before {
+    display: none;
+}
+
 .masthead:before {
   content: '';
   position: absolute;
@@ -34,10 +49,33 @@
     margin-bottom: 60px;
 }
 
+.masthead__notice {
+    max-width: 900px;
+    margin: 1.5rem auto 0;
+    padding: 1.5rem 2rem;
+    background: rgba(0, 0, 0, 0.6);
+    border: 1px solid rgba(255, 255, 255, 0.25);
+    border-radius: 8px;
+    text-shadow: none;
+}
+
+.masthead__notice h2 {
+    margin-top: 0;
+}
+
+.masthead__notice .info {
+    font-size: 1.1rem;
+}
+
 @media (max-width: 600px) {
     .masthead .livestream {
         height: 300px;
         border-left: none;
         border-right: none;
+    }
+
+    .masthead__notice {
+        margin: 1rem 1rem 0;
+        padding: 1rem 1.25rem;
     }
 }

--- a/pages/archiv.html
+++ b/pages/archiv.html
@@ -10,7 +10,7 @@ og_description: "Alle vergangenen Veranstaltungen des Technologieplauscherls auf
 {% for card in site.plauscherl reversed -%}
 {% assign cardTimeInSecondsInEpoch = card.startDateIso8601 | date: "%s" | plus: 0 -%}
 	{% comment -%} Only show past events in the archive based on the current time and event timestamp {% endcomment -%}
-	{% if cardTimeInSecondsInEpoch < buildTimeInSecondsInEpoch -%}
+	{% if card.layout == "post" and cardTimeInSecondsInEpoch < buildTimeInSecondsInEpoch -%}
 	{% include plauscherl-card.html -%}
 	{% endif -%}
 {% endfor -%}


### PR DESCRIPTION
* Event postpone info itself
    <img width="1813" height="840" alt="Info about TP93 being postponed" src="https://github.com/user-attachments/assets/688992b9-e47f-4b3d-b76d-ebcb2bb05357" />
* Add optional "additionalInfo" member to event entry
* Only event location when actually present
   <img width="461" height="106" alt="No location present, but additional info is shown" src="https://github.com/user-attachments/assets/2967d661-59cc-4d3d-b259-d878016dd039" />
* Hide non-"post" layouts in archive (useful if the current plauscherl does not use a "post" layout yet, but may change in the future)
* Show content of upcoming plauscherl if of layout type "page"
   <img width="1813" height="840" alt="Main page when upcoming event is a non-'post' entry" src="https://github.com/user-attachments/assets/f2fcd4af-9b08-4d0c-893f-739402a07857" />
