### PR TITLE
Add MIT License to website codebase

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,34 @@
+MIT License
+
+Copyright (c) 2012-2026 Technologieplauscherl Organizers and Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+---
+
+ADDITIONAL LICENSE NOTE:
+The MIT License applies strictly to the website layout, templates,
+and scripts (including HTML, CSS, SCSS, JavaScript, and Jekyll/Liquid
+templates).
+
+It does NOT apply to:
+1. The structured data files containing community events (including, but not
+limited to, `_data/community.yml`).
+2. The images, and branding assets, which remain the copyright of their
+respective owners.

--- a/README.md
+++ b/README.md
@@ -20,3 +20,11 @@ Dazu einfach das aktuellste Plauscherl-File unter /_plauscherl/ nehmen, und Folg
 ```
 bei einem Vortrag mit mehreren Speakern zu einem Thema, einfach einen weiteren Eintrag unter "speakers" hinzufügen.
 Das Bild ist optional und sollte idealerweise quadratisch sein. Dieses kann unter [img/speaker-avatars](./img/speaker-avatars) abgelegt und dann referenziert werden.
+
+## License
+
+This repository contains both the code for our website and community-submitted event data. To keep things simple, we split them as follows:
+
+* **The Code (MIT License):** The website software, layouts, Jekyll/Liquid templates, Sass/CSS, and JavaScript are licensed under the [MIT License](./LICENSE).
+* **Community Data:** The event listings and metadata stored in [`_data/community.yml`](./_data/community.yml) are factual directory listings. We do not claim copyright over these listings, but we ask that you respect the external meetup groups and links represented there.
+* **Images & Branding:** Logos, custom graphics, and photos in this repository are copyright of their respective owners and are not covered by the MIT license.


### PR DESCRIPTION
We got asked if our website code can be used as a base for new projects.
Internally @dmorawetz, @Flippochini and I discussed how to license it. Tthe agreement there was to add the MIT license to keep it simple yet open.

To clarify the open-source status, this PR adds the MIT license for the websites templates, styles and main scripts.
Key points on what is covered under what license:
* **Code:** Covered under MIT. Anyone can reuse our Jekyll structure
* **Community Data** ([community.yml](https://github.com/technologieplauscherl/technologieplauscherl.github.io/blob/master/_data/community.yml)): Clarified as factual directory listings that we do not claim copyright over
* Images & Branding: Specifically excluded from the MIT license to protect logos and other graphics

FYI: @ddprrt @saxx @hupfis @lischen3229 @arosemann @filR @tompson 

